### PR TITLE
Refactor redis commands out of redis proxy

### DIFF
--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -1,0 +1,40 @@
+licenses(["notice"])  # Apache 2
+
+# Redis proxy L4 network filter. Implements consistent hashing and observability for large redis
+# clusters.
+# Public docs: docs/root/configuration/network_filters/redis_proxy_filter.rst
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "codec_interface",
+    hdrs = ["codec.h"],
+    deps = ["//include/envoy/buffer:buffer_interface"],
+)
+
+envoy_cc_library(
+    name = "codec_lib",
+    srcs = ["codec_impl.cc"],
+    hdrs = ["codec_impl.h"],
+    deps = [
+        ":codec_interface",
+        "//source/common/common:assert_lib",
+        "//source/common/common:minimal_logger_lib",
+        "//source/common/common:stack_array",
+        "//source/common/common:utility_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "supported_commands_lib",
+    hdrs = ["supported_commands.h"],
+    deps = [
+        "//source/common/common:macros",
+    ],
+)

--- a/source/extensions/filters/network/common/redis/codec.h
+++ b/source/extensions/filters/network/common/redis/codec.h
@@ -10,7 +10,8 @@
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
-namespace RedisProxy {
+namespace Common {
+namespace Redis {
 
 /**
  * All RESP types as defined here: https://redis.io/topics/protocol
@@ -133,7 +134,8 @@ public:
   ProtocolError(const std::string& error) : EnvoyException(error) {}
 };
 
-} // namespace RedisProxy
+} // namespace Redis
+} // namespace Common
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/network/common/redis/codec_impl.cc
+++ b/source/extensions/filters/network/common/redis/codec_impl.cc
@@ -1,4 +1,4 @@
-#include "extensions/filters/network/redis_proxy/codec_impl.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 
 #include <cstdint>
 #include <memory>
@@ -13,7 +13,8 @@
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
-namespace RedisProxy {
+namespace Common {
+namespace Redis {
 
 std::string RespValue::toString() const {
   switch (type_) {
@@ -421,7 +422,8 @@ void EncoderImpl::encodeSimpleString(const std::string& string, Buffer::Instance
   out.add("\r\n", 2);
 }
 
-} // namespace RedisProxy
+} // namespace Redis
+} // namespace Common
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/network/common/redis/codec_impl.h
+++ b/source/extensions/filters/network/common/redis/codec_impl.h
@@ -7,12 +7,13 @@
 
 #include "common/common/logger.h"
 
-#include "extensions/filters/network/redis_proxy/codec.h"
+#include "extensions/filters/network/common/redis/codec.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
-namespace RedisProxy {
+namespace Common {
+namespace Redis {
 
 /**
  * Decoder implementation of https://redis.io/topics/protocol
@@ -91,7 +92,8 @@ private:
   void encodeSimpleString(const std::string& string, Buffer::Instance& out);
 };
 
-} // namespace RedisProxy
+} // namespace Redis
+} // namespace Common
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -8,7 +8,8 @@
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
-namespace RedisProxy {
+namespace Common {
+namespace Redis {
 
 struct SupportedCommands {
   /**
@@ -60,7 +61,8 @@ struct SupportedCommands {
   static const std::string& ping() { CONSTRUCT_ON_FIRST_USE(std::string, "ping"); }
 };
 
-} // namespace RedisProxy
+} // namespace Redis
+} // namespace Common 
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -13,36 +13,19 @@ load(
 envoy_package()
 
 envoy_cc_library(
-    name = "codec_interface",
-    hdrs = ["codec.h"],
-    deps = ["//include/envoy/buffer:buffer_interface"],
-)
-
-envoy_cc_library(
     name = "command_splitter_interface",
     hdrs = ["command_splitter.h"],
-    deps = [":codec_interface"],
+    deps = [
+        "//source/extensions/filters/network/common/redis:codec_interface",
+    ],
 )
 
 envoy_cc_library(
     name = "conn_pool_interface",
     hdrs = ["conn_pool.h"],
     deps = [
-        ":codec_interface",
+        "//source/extensions/filters/network/common/redis:codec_interface",
         "//include/envoy/upstream:cluster_manager_interface",
-    ],
-)
-
-envoy_cc_library(
-    name = "codec_lib",
-    srcs = ["codec_impl.cc"],
-    hdrs = ["codec_impl.h"],
-    deps = [
-        ":codec_interface",
-        "//source/common/common:assert_lib",
-        "//source/common/common:minimal_logger_lib",
-        "//source/common/common:stack_array",
-        "//source/common/common:utility_lib",
     ],
 )
 
@@ -53,7 +36,7 @@ envoy_cc_library(
     deps = [
         ":command_splitter_interface",
         ":conn_pool_interface",
-        ":supported_commands_lib",
+        "//source/extensions/filters/network/common/redis:supported_commands_lib",
         "//include/envoy/stats:stats_macros",
         "//include/envoy/stats:timespan",
         "//source/common/common:assert_lib",
@@ -68,8 +51,8 @@ envoy_cc_library(
     srcs = ["conn_pool_impl.cc"],
     hdrs = ["conn_pool_impl.h"],
     deps = [
-        ":codec_lib",
         ":conn_pool_interface",
+        "//source/extensions/filters/network/common/redis:codec_lib",
         "//include/envoy/router:router_interface",
         "//include/envoy/thread_local:thread_local_interface",
         "//include/envoy/upstream:cluster_manager_interface",
@@ -87,8 +70,8 @@ envoy_cc_library(
     srcs = ["proxy_filter.cc"],
     hdrs = ["proxy_filter.h"],
     deps = [
-        ":codec_interface",
         ":command_splitter_interface",
+        "//source/extensions/filters/network/common/redis:codec_interface",
         "//include/envoy/network:drain_decision_interface",
         "//include/envoy/network:filter_interface",
         "//include/envoy/upstream:cluster_manager_interface",
@@ -96,14 +79,6 @@ envoy_cc_library(
         "//source/common/common:assert_lib",
         "//source/common/config:utility_lib",
         "@envoy_api//envoy/config/filter/network/redis_proxy/v2:redis_proxy_cc",
-    ],
-)
-
-envoy_cc_library(
-    name = "supported_commands_lib",
-    hdrs = ["supported_commands.h"],
-    deps = [
-        "//source/common/common:macros",
     ],
 )
 
@@ -116,7 +91,7 @@ envoy_cc_library(
         "//source/common/config:filter_json_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
-        "//source/extensions/filters/network/redis_proxy:codec_lib",
+        "//source/extensions/filters/network/common/redis:codec_lib",
         "//source/extensions/filters/network/redis_proxy:command_splitter_lib",
         "//source/extensions/filters/network/redis_proxy:conn_pool_lib",
         "//source/extensions/filters/network/redis_proxy:proxy_filter_lib",

--- a/source/extensions/filters/network/redis_proxy/command_splitter.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter.h
@@ -4,7 +4,7 @@
 
 #include "envoy/common/pure.h"
 
-#include "extensions/filters/network/redis_proxy/codec.h"
+#include "extensions/filters/network/common/redis/codec.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -38,7 +38,7 @@ public:
    * Called when the response is ready.
    * @param value supplies the response which is now owned by the callee.
    */
-  virtual void onResponse(RespValuePtr&& value) PURE;
+  virtual void onResponse(Common::Redis::RespValuePtr&& value) PURE;
 };
 
 /**
@@ -57,7 +57,7 @@ public:
    *         been satisfied (via onResponse() being called). The splitter ALWAYS calls
    *         onResponse() for a given request.
    */
-  virtual SplitRequestPtr makeRequest(const RespValue& request, SplitCallbacks& callbacks) PURE;
+  virtual SplitRequestPtr makeRequest(const Common::Redis::RespValue& request, SplitCallbacks& callbacks) PURE;
 };
 
 } // namespace CommandSplitter

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -10,7 +10,7 @@
 #include "common/common/assert.h"
 #include "common/common/fmt.h"
 
-#include "extensions/filters/network/redis_proxy/supported_commands.h"
+#include "extensions/filters/network/common/redis/supported_commands.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -18,15 +18,15 @@ namespace NetworkFilters {
 namespace RedisProxy {
 namespace CommandSplitter {
 
-RespValuePtr Utility::makeError(const std::string& error) {
-  RespValuePtr response(new RespValue());
-  response->type(RespType::Error);
+Common::Redis::RespValuePtr Utility::makeError(const std::string& error) {
+  Common::Redis::RespValuePtr response(new Common::Redis::RespValue());
+  response->type(Common::Redis::RespType::Error);
   response->asString() = error;
   return response;
 }
 
 void SplitRequestBase::onWrongNumberOfArguments(SplitCallbacks& callbacks,
-                                                const RespValue& request) {
+                                                const Common::Redis::RespValue& request) {
   callbacks.onResponse(Utility::makeError(
       fmt::format("wrong number of arguments for '{}' command", request.asArray()[0].asString())));
 }
@@ -42,7 +42,7 @@ void SplitRequestBase::updateStats(const bool success) {
 
 SingleServerRequest::~SingleServerRequest() { ASSERT(!handle_); }
 
-void SingleServerRequest::onResponse(RespValuePtr&& response) {
+void SingleServerRequest::onResponse(Common::Redis::RespValuePtr&& response) {
   handle_ = nullptr;
   updateStats(true);
   callbacks_.onResponse(std::move(response));
@@ -60,7 +60,7 @@ void SingleServerRequest::cancel() {
 }
 
 SplitRequestPtr SimpleRequest::create(ConnPool::Instance& conn_pool,
-                                      const RespValue& incoming_request, SplitCallbacks& callbacks,
+                                      const Common::Redis::RespValue& incoming_request, SplitCallbacks& callbacks,
                                       CommandStats& command_stats, TimeSource& time_source) {
   std::unique_ptr<SimpleRequest> request_ptr{
       new SimpleRequest(callbacks, command_stats, time_source)};
@@ -76,7 +76,7 @@ SplitRequestPtr SimpleRequest::create(ConnPool::Instance& conn_pool,
 }
 
 SplitRequestPtr EvalRequest::create(ConnPool::Instance& conn_pool,
-                                    const RespValue& incoming_request, SplitCallbacks& callbacks,
+                                    const Common::Redis::RespValue& incoming_request, SplitCallbacks& callbacks,
                                     CommandStats& command_stats, TimeSource& time_source) {
 
   // EVAL looks like: EVAL script numkeys key [key ...] arg [arg ...]
@@ -121,24 +121,24 @@ void FragmentedRequest::onChildFailure(uint32_t index) {
 }
 
 SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
-                                    const RespValue& incoming_request, SplitCallbacks& callbacks,
+                                    const Common::Redis::RespValue& incoming_request, SplitCallbacks& callbacks,
                                     CommandStats& command_stats, TimeSource& time_source) {
   std::unique_ptr<MGETRequest> request_ptr{new MGETRequest(callbacks, command_stats, time_source)};
 
   request_ptr->num_pending_responses_ = incoming_request.asArray().size() - 1;
   request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
-  request_ptr->pending_response_ = std::make_unique<RespValue>();
-  request_ptr->pending_response_->type(RespType::Array);
-  std::vector<RespValue> responses(request_ptr->num_pending_responses_);
+  request_ptr->pending_response_ = std::make_unique<Common::Redis::RespValue>();
+  request_ptr->pending_response_->type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> responses(request_ptr->num_pending_responses_);
   request_ptr->pending_response_->asArray().swap(responses);
 
-  std::vector<RespValue> values(2);
-  values[0].type(RespType::BulkString);
+  std::vector<Common::Redis::RespValue> values(2);
+  values[0].type(Common::Redis::RespType::BulkString);
   values[0].asString() = "get";
-  values[1].type(RespType::BulkString);
-  RespValue single_mget;
-  single_mget.type(RespType::Array);
+  values[1].type(Common::Redis::RespType::BulkString);
+  Common::Redis::RespValue single_mget;
+  single_mget.type(Common::Redis::RespType::Array);
   single_mget.asArray().swap(values);
 
   for (uint64_t i = 1; i < incoming_request.asArray().size(); i++) {
@@ -157,28 +157,28 @@ SplitRequestPtr MGETRequest::create(ConnPool::Instance& conn_pool,
   return request_ptr->num_pending_responses_ > 0 ? std::move(request_ptr) : nullptr;
 }
 
-void MGETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
+void MGETRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) {
   pending_requests_[index].handle_ = nullptr;
 
   pending_response_->asArray()[index].type(value->type());
   switch (value->type()) {
-  case RespType::Array:
-  case RespType::Integer:
-  case RespType::SimpleString: {
-    pending_response_->asArray()[index].type(RespType::Error);
+  case Common::Redis::RespType::Array:
+  case Common::Redis::RespType::Integer:
+  case Common::Redis::RespType::SimpleString: {
+    pending_response_->asArray()[index].type(Common::Redis::RespType::Error);
     pending_response_->asArray()[index].asString() = Response::get().UpstreamProtocolError;
     error_count_++;
     break;
   }
-  case RespType::Error: {
+  case Common::Redis::RespType::Error: {
     error_count_++;
     FALLTHRU;
   }
-  case RespType::BulkString: {
+  case Common::Redis::RespType::BulkString: {
     pending_response_->asArray()[index].asString().swap(value->asString());
     break;
   }
-  case RespType::Null:
+  case Common::Redis::RespType::Null:
     break;
   }
 
@@ -191,7 +191,7 @@ void MGETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
 }
 
 SplitRequestPtr MSETRequest::create(ConnPool::Instance& conn_pool,
-                                    const RespValue& incoming_request, SplitCallbacks& callbacks,
+                                    const Common::Redis::RespValue& incoming_request, SplitCallbacks& callbacks,
                                     CommandStats& command_stats, TimeSource& time_source) {
   if ((incoming_request.asArray().size() - 1) % 2 != 0) {
     onWrongNumberOfArguments(callbacks, incoming_request);
@@ -203,16 +203,16 @@ SplitRequestPtr MSETRequest::create(ConnPool::Instance& conn_pool,
   request_ptr->num_pending_responses_ = (incoming_request.asArray().size() - 1) / 2;
   request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
-  request_ptr->pending_response_ = std::make_unique<RespValue>();
-  request_ptr->pending_response_->type(RespType::SimpleString);
+  request_ptr->pending_response_ = std::make_unique<Common::Redis::RespValue>();
+  request_ptr->pending_response_->type(Common::Redis::RespType::SimpleString);
 
-  std::vector<RespValue> values(3);
-  values[0].type(RespType::BulkString);
+  std::vector<Common::Redis::RespValue> values(3);
+  values[0].type(Common::Redis::RespType::BulkString);
   values[0].asString() = "set";
-  values[1].type(RespType::BulkString);
-  values[2].type(RespType::BulkString);
-  RespValue single_mset;
-  single_mset.type(RespType::Array);
+  values[1].type(Common::Redis::RespType::BulkString);
+  values[2].type(Common::Redis::RespType::BulkString);
+  Common::Redis::RespValue single_mset;
+  single_mset.type(Common::Redis::RespType::Array);
   single_mset.asArray().swap(values);
 
   uint64_t fragment_index = 0;
@@ -234,11 +234,11 @@ SplitRequestPtr MSETRequest::create(ConnPool::Instance& conn_pool,
   return request_ptr->num_pending_responses_ > 0 ? std::move(request_ptr) : nullptr;
 }
 
-void MSETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
+void MSETRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) {
   pending_requests_[index].handle_ = nullptr;
 
   switch (value->type()) {
-  case RespType::SimpleString: {
+  case Common::Redis::RespType::SimpleString: {
     if (value->asString() == Response::get().OK) {
       break;
     }
@@ -264,7 +264,7 @@ void MSETRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
 }
 
 SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
-                                                  const RespValue& incoming_request,
+                                                  const Common::Redis::RespValue& incoming_request,
                                                   SplitCallbacks& callbacks,
                                                   CommandStats& command_stats,
                                                   TimeSource& time_source) {
@@ -274,15 +274,15 @@ SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
   request_ptr->num_pending_responses_ = incoming_request.asArray().size() - 1;
   request_ptr->pending_requests_.reserve(request_ptr->num_pending_responses_);
 
-  request_ptr->pending_response_ = std::make_unique<RespValue>();
-  request_ptr->pending_response_->type(RespType::Integer);
+  request_ptr->pending_response_ = std::make_unique<Common::Redis::RespValue>();
+  request_ptr->pending_response_->type(Common::Redis::RespType::Integer);
 
-  std::vector<RespValue> values(2);
-  values[0].type(RespType::BulkString);
+  std::vector<Common::Redis::RespValue> values(2);
+  values[0].type(Common::Redis::RespType::BulkString);
   values[0].asString() = incoming_request.asArray()[0].asString();
-  values[1].type(RespType::BulkString);
-  RespValue single_fragment;
-  single_fragment.type(RespType::Array);
+  values[1].type(Common::Redis::RespType::BulkString);
+  Common::Redis::RespValue single_fragment;
+  single_fragment.type(Common::Redis::RespType::Array);
   single_fragment.asArray().swap(values);
 
   for (uint64_t i = 1; i < incoming_request.asArray().size(); i++) {
@@ -302,11 +302,11 @@ SplitRequestPtr SplitKeysSumResultRequest::create(ConnPool::Instance& conn_pool,
   return request_ptr->num_pending_responses_ > 0 ? std::move(request_ptr) : nullptr;
 }
 
-void SplitKeysSumResultRequest::onChildResponse(RespValuePtr&& value, uint32_t index) {
+void SplitKeysSumResultRequest::onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) {
   pending_requests_[index].handle_ = nullptr;
 
   switch (value->type()) {
-  case RespType::Integer: {
+  case Common::Redis::RespType::Integer: {
     total_ += value->asInteger();
     break;
   }
@@ -336,24 +336,24 @@ InstanceImpl::InstanceImpl(ConnPool::InstancePtr&& conn_pool, Stats::Scope& scop
       split_keys_sum_result_handler_(*conn_pool_),
       stats_{ALL_COMMAND_SPLITTER_STATS(POOL_COUNTER_PREFIX(scope, stat_prefix + "splitter."))},
       time_source_(time_source) {
-  for (const std::string& command : SupportedCommands::simpleCommands()) {
+  for (const std::string& command : Common::Redis::SupportedCommands::simpleCommands()) {
     addHandler(scope, stat_prefix, command, simple_command_handler_);
   }
 
-  for (const std::string& command : SupportedCommands::evalCommands()) {
+  for (const std::string& command : Common::Redis::SupportedCommands::evalCommands()) {
     addHandler(scope, stat_prefix, command, eval_command_handler_);
   }
 
-  for (const std::string& command : SupportedCommands::hashMultipleSumResultCommands()) {
+  for (const std::string& command : Common::Redis::SupportedCommands::hashMultipleSumResultCommands()) {
     addHandler(scope, stat_prefix, command, split_keys_sum_result_handler_);
   }
 
-  addHandler(scope, stat_prefix, SupportedCommands::mget(), mget_handler_);
-  addHandler(scope, stat_prefix, SupportedCommands::mset(), mset_handler_);
+  addHandler(scope, stat_prefix, Common::Redis::SupportedCommands::mget(), mget_handler_);
+  addHandler(scope, stat_prefix, Common::Redis::SupportedCommands::mset(), mset_handler_);
 }
 
-SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbacks& callbacks) {
-  if (request.type() != RespType::Array) {
+SplitRequestPtr InstanceImpl::makeRequest(const Common::Redis::RespValue& request, SplitCallbacks& callbacks) {
+  if (request.type() != Common::Redis::RespType::Array) {
     onInvalidRequest(callbacks);
     return nullptr;
   }
@@ -361,10 +361,10 @@ SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbac
   std::string to_lower_string(request.asArray()[0].asString());
   to_lower_table_.toLowerCase(to_lower_string);
 
-  if (to_lower_string == SupportedCommands::ping()) {
+  if (to_lower_string == Common::Redis::SupportedCommands::ping()) {
     // Respond to PING locally.
-    RespValuePtr pong(new RespValue());
-    pong->type(RespType::SimpleString);
+    Common::Redis::RespValuePtr pong(new Common::Redis::RespValue());
+    pong->type(Common::Redis::RespType::SimpleString);
     pong->asString() = "PONG";
     callbacks.onResponse(std::move(pong));
     return nullptr;
@@ -376,8 +376,8 @@ SplitRequestPtr InstanceImpl::makeRequest(const RespValue& request, SplitCallbac
     return nullptr;
   }
 
-  for (const RespValue& value : request.asArray()) {
-    if (value.type() != RespType::BulkString) {
+  for (const Common::Redis::RespValue& value : request.asArray()) {
+    if (value.type() != Common::Redis::RespType::BulkString) {
       onInvalidRequest(callbacks);
       return nullptr;
     }

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -35,7 +35,7 @@ typedef ConstSingleton<ResponseValues> Response;
 
 class Utility {
 public:
-  static RespValuePtr makeError(const std::string& error);
+  static Common::Redis::RespValuePtr makeError(const std::string& error);
 };
 
 /**
@@ -60,7 +60,7 @@ class CommandHandler {
 public:
   virtual ~CommandHandler() {}
 
-  virtual SplitRequestPtr startRequest(const RespValue& request, SplitCallbacks& callbacks,
+  virtual SplitRequestPtr startRequest(const Common::Redis::RespValue& request, SplitCallbacks& callbacks,
                                        CommandStats& command_stats, TimeSource& time_source) PURE;
 };
 
@@ -73,7 +73,7 @@ protected:
 
 class SplitRequestBase : public SplitRequest {
 protected:
-  static void onWrongNumberOfArguments(SplitCallbacks& callbacks, const RespValue& request);
+  static void onWrongNumberOfArguments(SplitCallbacks& callbacks, const Common::Redis::RespValue& request);
   void updateStats(const bool success);
 
   SplitRequestBase(CommandStats& command_stats, TimeSource& time_source)
@@ -92,7 +92,7 @@ public:
   ~SingleServerRequest();
 
   // RedisProxy::ConnPool::PoolCallbacks
-  void onResponse(RespValuePtr&& response) override;
+  void onResponse(Common::Redis::RespValuePtr&& response) override;
   void onFailure() override;
 
   // RedisProxy::CommandSplitter::SplitRequest
@@ -112,7 +112,7 @@ protected:
  */
 class SimpleRequest : public SingleServerRequest {
 public:
-  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
+  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const Common::Redis::RespValue& incoming_request,
                                 SplitCallbacks& callbacks, CommandStats& command_stats,
                                 TimeSource& time_source);
 
@@ -126,7 +126,7 @@ private:
  */
 class EvalRequest : public SingleServerRequest {
 public:
-  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
+  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const Common::Redis::RespValue& incoming_request,
                                 SplitCallbacks& callbacks, CommandStats& command_stats,
                                 TimeSource& time_source);
 
@@ -155,7 +155,7 @@ protected:
     PendingRequest(FragmentedRequest& parent, uint32_t index) : parent_(parent), index_(index) {}
 
     // RedisProxy::ConnPool::PoolCallbacks
-    void onResponse(RespValuePtr&& value) override {
+    void onResponse(Common::Redis::RespValuePtr&& value) override {
       parent_.onChildResponse(std::move(value), index_);
     }
     void onFailure() override { parent_.onChildFailure(index_); }
@@ -165,11 +165,11 @@ protected:
     ConnPool::PoolRequest* handle_{};
   };
 
-  virtual void onChildResponse(RespValuePtr&& value, uint32_t index) PURE;
+  virtual void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) PURE;
   void onChildFailure(uint32_t index);
 
   SplitCallbacks& callbacks_;
-  RespValuePtr pending_response_;
+  Common::Redis::RespValuePtr pending_response_;
   std::vector<PendingRequest> pending_requests_;
   uint32_t num_pending_responses_;
   uint32_t error_count_{0};
@@ -181,7 +181,7 @@ protected:
  */
 class MGETRequest : public FragmentedRequest, Logger::Loggable<Logger::Id::redis> {
 public:
-  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
+  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const Common::Redis::RespValue& incoming_request,
                                 SplitCallbacks& callbacks, CommandStats& command_stats,
                                 TimeSource& time_source);
 
@@ -190,7 +190,7 @@ private:
       : FragmentedRequest(callbacks, command_stats, time_source) {}
 
   // RedisProxy::CommandSplitter::FragmentedRequest
-  void onChildResponse(RespValuePtr&& value, uint32_t index) override;
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
 };
 
 /**
@@ -201,7 +201,7 @@ private:
  */
 class SplitKeysSumResultRequest : public FragmentedRequest, Logger::Loggable<Logger::Id::redis> {
 public:
-  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
+  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const Common::Redis::RespValue& incoming_request,
                                 SplitCallbacks& callbacks, CommandStats& command_stats,
                                 TimeSource& time_source);
 
@@ -211,7 +211,7 @@ private:
       : FragmentedRequest(callbacks, command_stats, time_source) {}
 
   // RedisProxy::CommandSplitter::FragmentedRequest
-  void onChildResponse(RespValuePtr&& value, uint32_t index) override;
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
 
   int64_t total_{0};
 };
@@ -223,7 +223,7 @@ private:
  */
 class MSETRequest : public FragmentedRequest, Logger::Loggable<Logger::Id::redis> {
 public:
-  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const RespValue& incoming_request,
+  static SplitRequestPtr create(ConnPool::Instance& conn_pool, const Common::Redis::RespValue& incoming_request,
                                 SplitCallbacks& callbacks, CommandStats& command_stats,
                                 TimeSource& time_source);
 
@@ -232,7 +232,7 @@ private:
       : FragmentedRequest(callbacks, command_stats, time_source) {}
 
   // RedisProxy::CommandSplitter::FragmentedRequest
-  void onChildResponse(RespValuePtr&& value, uint32_t index) override;
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
 };
 
 /**
@@ -243,7 +243,7 @@ template <class RequestClass>
 class CommandHandlerFactory : public CommandHandler, CommandHandlerBase {
 public:
   CommandHandlerFactory(ConnPool::Instance& conn_pool) : CommandHandlerBase(conn_pool) {}
-  SplitRequestPtr startRequest(const RespValue& request, SplitCallbacks& callbacks,
+  SplitRequestPtr startRequest(const Common::Redis::RespValue& request, SplitCallbacks& callbacks,
                                CommandStats& command_stats, TimeSource& time_source) {
     return RequestClass::create(conn_pool_, request, callbacks, command_stats, time_source);
   }
@@ -271,7 +271,7 @@ public:
                const std::string& stat_prefix, TimeSource& time_source);
 
   // RedisProxy::CommandSplitter::Instance
-  SplitRequestPtr makeRequest(const RespValue& request, SplitCallbacks& callbacks) override;
+  SplitRequestPtr makeRequest(const Common::Redis::RespValue& request, SplitCallbacks& callbacks) override;
 
 private:
   struct HandlerData {

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -8,7 +8,7 @@
 
 #include "common/config/filter_json.h"
 
-#include "extensions/filters/network/redis_proxy/codec_impl.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/redis_proxy/command_splitter_impl.h"
 #include "extensions/filters/network/redis_proxy/conn_pool_impl.h"
 #include "extensions/filters/network/redis_proxy/proxy_filter.h"
@@ -34,9 +34,9 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
   std::shared_ptr<CommandSplitter::Instance> splitter(new CommandSplitter::InstanceImpl(
       std::move(conn_pool), context.scope(), filter_config->stat_prefix_, context.timeSource()));
   return [splitter, filter_config](Network::FilterManager& filter_manager) -> void {
-    DecoderFactoryImpl factory;
+    Common::Redis::DecoderFactoryImpl factory;
     filter_manager.addReadFilter(std::make_shared<ProxyFilter>(
-        factory, EncoderPtr{new EncoderImpl()}, *splitter, filter_config));
+        factory, Common::Redis::EncoderPtr{new Common::Redis::EncoderImpl()}, *splitter, filter_config));
   };
 }
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool.h
@@ -6,7 +6,7 @@
 
 #include "envoy/upstream/cluster_manager.h"
 
-#include "extensions/filters/network/redis_proxy/codec.h"
+#include "extensions/filters/network/common/redis/codec.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -38,7 +38,7 @@ public:
    * Called when a pipelined response is received.
    * @param value supplies the response which is now owned by the callee.
    */
-  virtual void onResponse(RespValuePtr&& value) PURE;
+  virtual void onResponse(Common::Redis::RespValuePtr&& value) PURE;
 
   /**
    * Called when a network/protocol error occurs and there is no response.
@@ -70,7 +70,7 @@ public:
    * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
    *         for some reason.
    */
-  virtual PoolRequest* makeRequest(const RespValue& request, PoolCallbacks& callbacks) PURE;
+  virtual PoolRequest* makeRequest(const Common::Redis::RespValue& request, PoolCallbacks& callbacks) PURE;
 };
 
 typedef std::unique_ptr<Client> ClientPtr;
@@ -136,7 +136,7 @@ public:
    * @return PoolRequest* a handle to the active request or nullptr if the request could not be made
    *         for some reason.
    */
-  virtual PoolRequest* makeRequest(const std::string& hash_key, const RespValue& request,
+  virtual PoolRequest* makeRequest(const std::string& hash_key, const Common::Redis::RespValue& request,
                                    PoolCallbacks& callbacks) PURE;
 };
 

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.cc
@@ -19,7 +19,7 @@ ConfigImpl::ConfigImpl(
       enable_hashtagging_(config.enable_hashtagging()) {}
 
 ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                             EncoderPtr&& encoder, DecoderFactory& decoder_factory,
+                             Common::Redis::EncoderPtr&& encoder, Common::Redis::DecoderFactory& decoder_factory,
                              const Config& config) {
 
   std::unique_ptr<ClientImpl> client(
@@ -33,7 +33,7 @@ ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatche
 }
 
 ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                       EncoderPtr&& encoder, DecoderFactory& decoder_factory, const Config& config)
+                       Common::Redis::EncoderPtr&& encoder, Common::Redis::DecoderFactory& decoder_factory, const Config& config)
     : host_(host), encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)),
       config_(config),
       connect_or_op_timer_(dispatcher.createTimer([this]() -> void { onConnectOrOpTimeout(); })) {
@@ -53,7 +53,7 @@ ClientImpl::~ClientImpl() {
 
 void ClientImpl::close() { connection_->close(Network::ConnectionCloseType::NoFlush); }
 
-PoolRequest* ClientImpl::makeRequest(const RespValue& request, PoolCallbacks& callbacks) {
+PoolRequest* ClientImpl::makeRequest(const Common::Redis::RespValue& request, PoolCallbacks& callbacks) {
   ASSERT(connection_->state() == Network::Connection::State::Open);
 
   pending_requests_.emplace_back(*this, callbacks);
@@ -89,7 +89,7 @@ void ClientImpl::onConnectOrOpTimeout() {
 void ClientImpl::onData(Buffer::Instance& data) {
   try {
     decoder_->decode(data);
-  } catch (ProtocolError&) {
+  } catch (Common::Redis::ProtocolError&) {
     putOutlierEvent(Upstream::Outlier::Result::REQUEST_FAILED);
     host_->cluster().stats().upstream_cx_protocol_error_.inc();
     host_->stats().rq_error_.inc();
@@ -140,7 +140,7 @@ void ClientImpl::onEvent(Network::ConnectionEvent event) {
   }
 }
 
-void ClientImpl::onRespValue(RespValuePtr&& value) {
+void ClientImpl::onRespValue(Common::Redis::RespValuePtr&& value) {
   ASSERT(!pending_requests_.empty());
   PendingRequest& request = pending_requests_.front();
   if (!request.canceled_) {
@@ -185,7 +185,7 @@ ClientFactoryImpl ClientFactoryImpl::instance_;
 
 ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
                                     Event::Dispatcher& dispatcher, const Config& config) {
-  return ClientImpl::create(host, dispatcher, EncoderPtr{new EncoderImpl()}, decoder_factory_,
+  return ClientImpl::create(host, dispatcher, Common::Redis::EncoderPtr{new Common::Redis::EncoderImpl()}, decoder_factory_,
                             config);
 }
 
@@ -200,7 +200,7 @@ InstanceImpl::InstanceImpl(
   });
 }
 
-PoolRequest* InstanceImpl::makeRequest(const std::string& key, const RespValue& value,
+PoolRequest* InstanceImpl::makeRequest(const std::string& key, const Common::Redis::RespValue& value,
                                        PoolCallbacks& callbacks) {
   return tls_->getTyped<ThreadLocalPool>().makeRequest(key, value, callbacks);
 }
@@ -274,7 +274,7 @@ void InstanceImpl::ThreadLocalPool::onHostsRemoved(
 }
 
 PoolRequest* InstanceImpl::ThreadLocalPool::makeRequest(const std::string& key,
-                                                        const RespValue& request,
+                                                        const Common::Redis::RespValue& request,
                                                         PoolCallbacks& callbacks) {
   if (cluster_ == nullptr) {
     ASSERT(client_map_.empty());

--- a/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
+++ b/source/extensions/filters/network/redis_proxy/conn_pool_impl.h
@@ -18,7 +18,7 @@
 #include "common/protobuf/utility.h"
 #include "common/upstream/load_balancer_impl.h"
 
-#include "extensions/filters/network/redis_proxy/codec_impl.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 
 namespace Envoy {
@@ -44,10 +44,10 @@ private:
   const bool enable_hashtagging_;
 };
 
-class ClientImpl : public Client, public DecoderCallbacks, public Network::ConnectionCallbacks {
+class ClientImpl : public Client, public Common::Redis::DecoderCallbacks, public Network::ConnectionCallbacks {
 public:
   static ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                          EncoderPtr&& encoder, DecoderFactory& decoder_factory,
+                          Common::Redis::EncoderPtr&& encoder, Common::Redis::DecoderFactory& decoder_factory,
                           const Config& config);
 
   ~ClientImpl();
@@ -57,7 +57,7 @@ public:
     connection_->addConnectionCallbacks(callbacks);
   }
   void close() override;
-  PoolRequest* makeRequest(const RespValue& request, PoolCallbacks& callbacks) override;
+  PoolRequest* makeRequest(const Common::Redis::RespValue& request, PoolCallbacks& callbacks) override;
 
 private:
   struct UpstreamReadFilter : public Network::ReadFilterBaseImpl {
@@ -84,14 +84,14 @@ private:
     bool canceled_{};
   };
 
-  ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher, EncoderPtr&& encoder,
-             DecoderFactory& decoder_factory, const Config& config);
+  ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher, Common::Redis::EncoderPtr&& encoder,
+             Common::Redis::DecoderFactory& decoder_factory, const Config& config);
   void onConnectOrOpTimeout();
   void onData(Buffer::Instance& data);
   void putOutlierEvent(Upstream::Outlier::Result result);
 
-  // RedisProxy::DecoderCallbacks
-  void onRespValue(RespValuePtr&& value) override;
+  // Common::Redis::DecoderCallbacks
+  void onRespValue(Common::Redis::RespValuePtr&& value) override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;
@@ -100,9 +100,9 @@ private:
 
   Upstream::HostConstSharedPtr host_;
   Network::ClientConnectionPtr connection_;
-  EncoderPtr encoder_;
+  Common::Redis::EncoderPtr encoder_;
   Buffer::OwnedImpl encoder_buffer_;
-  DecoderPtr decoder_;
+  Common::Redis::DecoderPtr decoder_;
   const Config& config_;
   std::list<PendingRequest> pending_requests_;
   Event::TimerPtr connect_or_op_timer_;
@@ -118,7 +118,7 @@ public:
   static ClientFactoryImpl instance_;
 
 private:
-  DecoderFactoryImpl decoder_factory_;
+  Common::Redis::DecoderFactoryImpl decoder_factory_;
 };
 
 class InstanceImpl : public Instance {
@@ -129,7 +129,7 @@ public:
       const envoy::config::filter::network::redis_proxy::v2::RedisProxy::ConnPoolSettings& config);
 
   // RedisProxy::ConnPool::Instance
-  PoolRequest* makeRequest(const std::string& key, const RespValue& request,
+  PoolRequest* makeRequest(const std::string& key, const Common::Redis::RespValue& request,
                            PoolCallbacks& callbacks) override;
 
 private:
@@ -154,7 +154,7 @@ private:
                            public Upstream::ClusterUpdateCallbacks {
     ThreadLocalPool(InstanceImpl& parent, Event::Dispatcher& dispatcher, std::string cluster_name);
     ~ThreadLocalPool();
-    PoolRequest* makeRequest(const std::string& key, const RespValue& request,
+    PoolRequest* makeRequest(const std::string& key, const Common::Redis::RespValue& request,
                              PoolCallbacks& callbacks);
     void onClusterAddOrUpdateNonVirtual(Upstream::ThreadLocalCluster& cluster);
     void onHostsRemoved(const std::vector<Upstream::HostSharedPtr>& hosts_removed);

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.cc
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.cc
@@ -26,7 +26,7 @@ ProxyStats ProxyFilterConfig::generateStats(const std::string& prefix, Stats::Sc
       ALL_REDIS_PROXY_STATS(POOL_COUNTER_PREFIX(scope, prefix), POOL_GAUGE_PREFIX(scope, prefix))};
 }
 
-ProxyFilter::ProxyFilter(DecoderFactory& factory, EncoderPtr&& encoder,
+ProxyFilter::ProxyFilter(Common::Redis::DecoderFactory& factory, Common::Redis::EncoderPtr&& encoder,
                          CommandSplitter::Instance& splitter, ProxyFilterConfigSharedPtr config)
     : decoder_(factory.create(*this)), encoder_(std::move(encoder)), splitter_(splitter),
       config_(config) {
@@ -49,7 +49,7 @@ void ProxyFilter::initializeReadFilterCallbacks(Network::ReadFilterCallbacks& ca
                                                nullptr, nullptr});
 }
 
-void ProxyFilter::onRespValue(RespValuePtr&& value) {
+void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value) {
   pending_requests_.emplace_back(*this);
   PendingRequest& request = pending_requests_.back();
   CommandSplitter::SplitRequestPtr split = splitter_.makeRequest(*value, request);
@@ -72,7 +72,7 @@ void ProxyFilter::onEvent(Network::ConnectionEvent event) {
   }
 }
 
-void ProxyFilter::onResponse(PendingRequest& request, RespValuePtr&& value) {
+void ProxyFilter::onResponse(PendingRequest& request, Common::Redis::RespValuePtr&& value) {
   ASSERT(!pending_requests_.empty());
   request.pending_response_ = std::move(value);
   request.request_handle_ = nullptr;
@@ -100,10 +100,10 @@ Network::FilterStatus ProxyFilter::onData(Buffer::Instance& data, bool) {
   try {
     decoder_->decode(data);
     return Network::FilterStatus::Continue;
-  } catch (ProtocolError&) {
+  } catch (Common::Redis::ProtocolError&) {
     config_->stats_.downstream_cx_protocol_error_.inc();
-    RespValue error;
-    error.type(RespType::Error);
+    Common::Redis::RespValue error;
+    error.type(Common::Redis::RespType::Error);
     error.asString() = "downstream protocol error";
     encoder_->encode(error, encoder_buffer_);
     callbacks_->connection().write(encoder_buffer_, false);

--- a/source/extensions/filters/network/redis_proxy/proxy_filter.h
+++ b/source/extensions/filters/network/redis_proxy/proxy_filter.h
@@ -13,7 +13,7 @@
 
 #include "common/buffer/buffer_impl.h"
 
-#include "extensions/filters/network/redis_proxy/codec.h"
+#include "extensions/filters/network/common/redis/codec.h"
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
 
 namespace Envoy {
@@ -72,10 +72,10 @@ typedef std::shared_ptr<ProxyFilterConfig> ProxyFilterConfigSharedPtr;
  * multiplex them onto a consistently hashed connection pool of backend servers.
  */
 class ProxyFilter : public Network::ReadFilter,
-                    public DecoderCallbacks,
+                    public Common::Redis::DecoderCallbacks,
                     public Network::ConnectionCallbacks {
 public:
-  ProxyFilter(DecoderFactory& factory, EncoderPtr&& encoder, CommandSplitter::Instance& splitter,
+  ProxyFilter(Common::Redis::DecoderFactory& factory, Common::Redis::EncoderPtr&& encoder, CommandSplitter::Instance& splitter,
               ProxyFilterConfigSharedPtr config);
   ~ProxyFilter();
 
@@ -89,8 +89,8 @@ public:
   void onAboveWriteBufferHighWatermark() override {}
   void onBelowWriteBufferLowWatermark() override {}
 
-  // RedisProxy::DecoderCallbacks
-  void onRespValue(RespValuePtr&& value) override;
+  // Common::Redis::DecoderCallbacks
+  void onRespValue(Common::Redis::RespValuePtr&& value) override;
 
 private:
   struct PendingRequest : public CommandSplitter::SplitCallbacks {
@@ -98,17 +98,17 @@ private:
     ~PendingRequest();
 
     // RedisProxy::CommandSplitter::SplitCallbacks
-    void onResponse(RespValuePtr&& value) override { parent_.onResponse(*this, std::move(value)); }
+    void onResponse(Common::Redis::RespValuePtr&& value) override { parent_.onResponse(*this, std::move(value)); }
 
     ProxyFilter& parent_;
-    RespValuePtr pending_response_;
+    Common::Redis::RespValuePtr pending_response_;
     CommandSplitter::SplitRequestPtr request_handle_;
   };
 
-  void onResponse(PendingRequest& request, RespValuePtr&& value);
+  void onResponse(PendingRequest& request, Common::Redis::RespValuePtr&& value);
 
-  DecoderPtr decoder_;
-  EncoderPtr encoder_;
+  Common::Redis::DecoderPtr decoder_;
+  Common::Redis::EncoderPtr encoder_;
   CommandSplitter::Instance& splitter_;
   ProxyFilterConfigSharedPtr config_;
   Buffer::OwnedImpl encoder_buffer_;

--- a/source/extensions/health_checkers/redis/redis.cc
+++ b/source/extensions/health_checkers/redis/redis.cc
@@ -65,12 +65,12 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onInterval() {
 }
 
 void RedisHealthChecker::RedisActiveHealthCheckSession::onResponse(
-    Extensions::NetworkFilters::RedisProxy::RespValuePtr&& value) {
+    NetworkFilters::Common::Redis::RespValuePtr&& value) {
   current_request_ = nullptr;
 
   switch (parent_.type_) {
   case Type::Exists:
-    if (value->type() == Extensions::NetworkFilters::RedisProxy::RespType::Integer &&
+    if (value->type() == NetworkFilters::Common::Redis::RespType::Integer &&
         value->asInteger() == 0) {
       handleSuccess();
     } else {
@@ -78,7 +78,7 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onResponse(
     }
     break;
   case Type::Ping:
-    if (value->type() == Extensions::NetworkFilters::RedisProxy::RespType::SimpleString &&
+    if (value->type() == NetworkFilters::Common::Redis::RespType::SimpleString &&
         value->asString() == "PONG") {
       handleSuccess();
     } else {
@@ -106,20 +106,20 @@ void RedisHealthChecker::RedisActiveHealthCheckSession::onTimeout() {
 }
 
 RedisHealthChecker::HealthCheckRequest::HealthCheckRequest(const std::string& key) {
-  std::vector<Extensions::NetworkFilters::RedisProxy::RespValue> values(2);
-  values[0].type(Extensions::NetworkFilters::RedisProxy::RespType::BulkString);
+  std::vector<NetworkFilters::Common::Redis::RespValue> values(2);
+  values[0].type(NetworkFilters::Common::Redis::RespType::BulkString);
   values[0].asString() = "EXISTS";
-  values[1].type(Extensions::NetworkFilters::RedisProxy::RespType::BulkString);
+  values[1].type(NetworkFilters::Common::Redis::RespType::BulkString);
   values[1].asString() = key;
-  request_.type(Extensions::NetworkFilters::RedisProxy::RespType::Array);
+  request_.type(NetworkFilters::Common::Redis::RespType::Array);
   request_.asArray().swap(values);
 }
 
 RedisHealthChecker::HealthCheckRequest::HealthCheckRequest() {
-  std::vector<Extensions::NetworkFilters::RedisProxy::RespValue> values(1);
-  values[0].type(Extensions::NetworkFilters::RedisProxy::RespType::BulkString);
+  std::vector<NetworkFilters::Common::Redis::RespValue> values(1);
+  values[0].type(NetworkFilters::Common::Redis::RespType::BulkString);
   values[0].asString() = "PING";
-  request_.type(Extensions::NetworkFilters::RedisProxy::RespType::Array);
+  request_.type(NetworkFilters::Common::Redis::RespType::Array);
   request_.asArray().swap(values);
 }
 

--- a/source/extensions/health_checkers/redis/redis.h
+++ b/source/extensions/health_checkers/redis/redis.h
@@ -23,12 +23,12 @@ public:
       Upstream::HealthCheckEventLoggerPtr&& event_logger,
       Extensions::NetworkFilters::RedisProxy::ConnPool::ClientFactory& client_factory);
 
-  static const Extensions::NetworkFilters::RedisProxy::RespValue& pingHealthCheckRequest() {
+  static const NetworkFilters::Common::Redis::RespValue& pingHealthCheckRequest() {
     static HealthCheckRequest* request = new HealthCheckRequest();
     return request->request_;
   }
 
-  static const Extensions::NetworkFilters::RedisProxy::RespValue&
+  static const NetworkFilters::Common::Redis::RespValue&
   existsHealthCheckRequest(const std::string& key) {
     static HealthCheckRequest* request = new HealthCheckRequest(key);
     return request->request_;
@@ -60,7 +60,7 @@ private:
     bool enableHashtagging() const override { return false; }
 
     // Extensions::NetworkFilters::RedisProxy::ConnPool::PoolCallbacks
-    void onResponse(Extensions::NetworkFilters::RedisProxy::RespValuePtr&& value) override;
+    void onResponse(NetworkFilters::Common::Redis::RespValuePtr&& value) override;
     void onFailure() override;
 
     // Network::ConnectionCallbacks
@@ -79,7 +79,7 @@ private:
     HealthCheckRequest(const std::string& key);
     HealthCheckRequest();
 
-    Extensions::NetworkFilters::RedisProxy::RespValue request_;
+    NetworkFilters::Common::Redis::RespValue request_;
   };
 
   typedef std::unique_ptr<RedisActiveHealthCheckSession> RedisActiveHealthCheckSessionPtr;

--- a/test/extensions/filters/network/common/redis/BUILD
+++ b/test/extensions/filters/network/common/redis/BUILD
@@ -1,0 +1,27 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_mock",
+    "envoy_package",
+)
+load(
+    "//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+    "envoy_extension_cc_test_binary",
+)
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "codec_impl_test",
+    srcs = ["codec_impl_test.cc"],
+    extension_name = "envoy.filters.network.common.redis",
+    deps = [
+        "//source/common/buffer:buffer_lib",
+        "//source/common/common:assert_lib",
+        "//source/extensions/filters/network/common/redis:codec_lib",
+        "//test/test_common:utility_lib",
+    ],
+)
+

--- a/test/extensions/filters/network/common/redis/codec_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/codec_impl_test.cc
@@ -3,9 +3,8 @@
 #include "common/buffer/buffer_impl.h"
 #include "common/common/assert.h"
 
-#include "extensions/filters/network/redis_proxy/codec_impl.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 
-#include "test/extensions/filters/network/redis_proxy/mocks.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
@@ -14,7 +13,8 @@
 namespace Envoy {
 namespace Extensions {
 namespace NetworkFilters {
-namespace RedisProxy {
+namespace Common {
+namespace Redis {
 
 class RedisEncoderDecoderImplTest : public testing::Test, public DecoderCallbacks {
 public:
@@ -188,7 +188,8 @@ TEST_F(RedisEncoderDecoderImplTest, InvalidBulkStringExpectLF) {
   EXPECT_THROW(decoder_.decode(buffer_), ProtocolError);
 }
 
-} // namespace RedisProxy
+} // namespace Redis
+} // namespace Common 
 } // namespace NetworkFilters
 } // namespace Extensions
 } // namespace Envoy

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -14,19 +14,6 @@ load(
 envoy_package()
 
 envoy_extension_cc_test(
-    name = "codec_impl_test",
-    srcs = ["codec_impl_test.cc"],
-    extension_name = "envoy.filters.network.redis_proxy",
-    deps = [
-        ":redis_mocks",
-        "//source/common/buffer:buffer_lib",
-        "//source/common/common:assert_lib",
-        "//source/extensions/filters/network/redis_proxy:codec_lib",
-        "//test/test_common:utility_lib",
-    ],
-)
-
-envoy_extension_cc_test(
     name = "command_splitter_impl_test",
     srcs = ["command_splitter_impl_test.cc"],
     extension_name = "envoy.filters.network.redis_proxy",

--- a/test/extensions/filters/network/redis_proxy/BUILD
+++ b/test/extensions/filters/network/redis_proxy/BUILD
@@ -67,7 +67,7 @@ envoy_cc_mock(
     hdrs = ["mocks.h"],
     deps = [
         "//source/common/common:assert_lib",
-        "//source/extensions/filters/network/redis_proxy:codec_lib",
+        "//source/extensions/filters/network/common/redis:codec_lib",
         "//source/extensions/filters/network/redis_proxy:command_splitter_interface",
         "//source/extensions/filters/network/redis_proxy:conn_pool_interface",
     ],

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -7,7 +7,7 @@
 #include "common/stats/isolated_store_impl.h"
 
 #include "extensions/filters/network/redis_proxy/command_splitter_impl.h"
-#include "extensions/filters/network/redis_proxy/supported_commands.h"
+#include "extensions/filters/network/common/redis/supported_commands.h"
 
 #include "test/extensions/filters/network/redis_proxy/mocks.h"
 #include "test/mocks/common.h"
@@ -37,14 +37,14 @@ namespace CommandSplitter {
 
 class RedisCommandSplitterImplTest : public testing::Test {
 public:
-  void makeBulkStringArray(RespValue& value, const std::vector<std::string>& strings) {
-    std::vector<RespValue> values(strings.size());
+  void makeBulkStringArray(Common::Redis::RespValue& value, const std::vector<std::string>& strings) {
+    std::vector<Common::Redis::RespValue> values(strings.size());
     for (uint64_t i = 0; i < strings.size(); i++) {
-      values[i].type(RespType::BulkString);
+      values[i].type(Common::Redis::RespType::BulkString);
       values[i].asString() = strings[i];
     }
 
-    value.type(RespType::Array);
+    value.type(Common::Redis::RespType::Array);
     value.asArray().swap(values);
   }
 
@@ -57,22 +57,22 @@ public:
 };
 
 TEST_F(RedisCommandSplitterImplTest, InvalidRequestNotArray) {
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
   response.asString() = Response::get().InvalidRequest;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
-  RespValue request;
+  Common::Redis::RespValue request;
   EXPECT_EQ(nullptr, splitter_.makeRequest(request, callbacks_));
 
   EXPECT_EQ(1UL, store_.counter("redis.foo.splitter.invalid_request").value());
 }
 
 TEST_F(RedisCommandSplitterImplTest, InvalidRequestArrayTooSmall) {
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
   response.asString() = Response::get().InvalidRequest;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"incr"});
   EXPECT_EQ(nullptr, splitter_.makeRequest(request, callbacks_));
 
@@ -80,24 +80,24 @@ TEST_F(RedisCommandSplitterImplTest, InvalidRequestArrayTooSmall) {
 }
 
 TEST_F(RedisCommandSplitterImplTest, InvalidRequestArrayNotStrings) {
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
   response.asString() = Response::get().InvalidRequest;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"incr", ""});
-  request.asArray()[1].type(RespType::Null);
+  request.asArray()[1].type(Common::Redis::RespType::Null);
   EXPECT_EQ(nullptr, splitter_.makeRequest(request, callbacks_));
 
   EXPECT_EQ(1UL, store_.counter("redis.foo.splitter.invalid_request").value());
 }
 
 TEST_F(RedisCommandSplitterImplTest, UnsupportedCommand) {
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
   response.asString() = "unsupported command 'newcommand'";
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"newcommand", "hello"});
   EXPECT_EQ(nullptr, splitter_.makeRequest(request, callbacks_));
 
@@ -107,23 +107,23 @@ TEST_F(RedisCommandSplitterImplTest, UnsupportedCommand) {
 class RedisSingleServerRequestTest : public RedisCommandSplitterImplTest,
                                      public testing::WithParamInterface<std::string> {
 public:
-  void makeRequest(const std::string& hash_key, const RespValue& request) {
+  void makeRequest(const std::string& hash_key, const Common::Redis::RespValue& request) {
     EXPECT_CALL(*conn_pool_, makeRequest(hash_key, Ref(request), _))
         .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callbacks_)), Return(&pool_request_)));
     handle_ = splitter_.makeRequest(request, callbacks_);
   }
 
   void fail() {
-    RespValue response;
-    response.type(RespType::Error);
+    Common::Redis::RespValue response;
+    response.type(Common::Redis::RespType::Error);
     response.asString() = Response::get().UpstreamFailure;
     EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
     pool_callbacks_->onFailure();
   }
 
   void respond() {
-    RespValuePtr response1(new RespValue());
-    RespValue* response1_ptr = response1.get();
+    Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+    Common::Redis::RespValue* response1_ptr = response1.get();
     EXPECT_CALL(callbacks_, onResponse_(PointeesEq(response1_ptr)));
     pool_callbacks_->onResponse(std::move(response1));
   }
@@ -139,7 +139,7 @@ TEST_P(RedisSingleServerRequestTest, Success) {
   std::string lower_command(GetParam());
   table.toLowerCase(lower_command);
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {GetParam(), "hello"});
   makeRequest("hello", request);
   EXPECT_NE(nullptr, handle_);
@@ -159,7 +159,7 @@ TEST_P(RedisSingleServerRequestTest, Success) {
 TEST_P(RedisSingleServerRequestTest, SuccessMultipleArgs) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {GetParam(), "hello", "123", "world"});
   makeRequest("hello", request);
   EXPECT_NE(nullptr, handle_);
@@ -183,7 +183,7 @@ TEST_P(RedisSingleServerRequestTest, SuccessMultipleArgs) {
 TEST_P(RedisSingleServerRequestTest, Fail) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {GetParam(), "hello"});
   makeRequest("hello", request);
   EXPECT_NE(nullptr, handle_);
@@ -206,7 +206,7 @@ TEST_P(RedisSingleServerRequestTest, Fail) {
 TEST_P(RedisSingleServerRequestTest, Cancel) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {GetParam(), "hello"});
   makeRequest("hello", request);
   EXPECT_NE(nullptr, handle_);
@@ -218,11 +218,11 @@ TEST_P(RedisSingleServerRequestTest, Cancel) {
 TEST_P(RedisSingleServerRequestTest, NoUpstream) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {GetParam(), "hello"});
   EXPECT_CALL(*conn_pool_, makeRequest("hello", Ref(request), _)).WillOnce(Return(nullptr));
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
   response.asString() = Response::get().NoUpstreamHost;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   handle_ = splitter_.makeRequest(request, callbacks_);
@@ -230,7 +230,7 @@ TEST_P(RedisSingleServerRequestTest, NoUpstream) {
 };
 
 INSTANTIATE_TEST_SUITE_P(RedisSingleServerRequestTest, RedisSingleServerRequestTest,
-                         testing::ValuesIn(SupportedCommands::simpleCommands()));
+                         testing::ValuesIn(Common::Redis::SupportedCommands::simpleCommands()));
 
 INSTANTIATE_TEST_SUITE_P(RedisSimpleRequestCommandHandlerMixedCaseTests,
                          RedisSingleServerRequestTest, testing::Values("INCR", "inCrBY"));
@@ -238,11 +238,11 @@ INSTANTIATE_TEST_SUITE_P(RedisSimpleRequestCommandHandlerMixedCaseTests,
 TEST_F(RedisSingleServerRequestTest, PingSuccess) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"ping"});
 
-  RespValue response;
-  response.type(RespType::SimpleString);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::SimpleString);
   response.asString() = "PONG";
 
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
@@ -253,7 +253,7 @@ TEST_F(RedisSingleServerRequestTest, PingSuccess) {
 TEST_F(RedisSingleServerRequestTest, EvalSuccess) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"eval", "return {ARGV[1]}", "1", "key", "arg"});
   makeRequest("key", request);
   EXPECT_NE(nullptr, handle_);
@@ -277,7 +277,7 @@ TEST_F(RedisSingleServerRequestTest, EvalSuccess) {
 TEST_F(RedisSingleServerRequestTest, EvalShaSuccess) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"EVALSHA", "return {ARGV[1]}", "1", "keykey", "arg"});
   makeRequest("keykey", request);
   EXPECT_NE(nullptr, handle_);
@@ -301,9 +301,9 @@ TEST_F(RedisSingleServerRequestTest, EvalShaSuccess) {
 TEST_F(RedisSingleServerRequestTest, EvalWrongNumberOfArgs) {
   InSequence s;
 
-  RespValue request;
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue request;
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
 
   response.asString() = "wrong number of arguments for 'eval' command";
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
@@ -319,11 +319,11 @@ TEST_F(RedisSingleServerRequestTest, EvalWrongNumberOfArgs) {
 TEST_F(RedisSingleServerRequestTest, EvalNoUpstream) {
   InSequence s;
 
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"eval", "return {ARGV[1]}", "1", "key", "arg"});
   EXPECT_CALL(*conn_pool_, makeRequest("key", Ref(request), _)).WillOnce(Return(nullptr));
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
   response.asString() = Response::get().NoUpstreamHost;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   handle_ = splitter_.makeRequest(request, callbacks_);
@@ -341,10 +341,10 @@ public:
       request_strings.push_back(std::to_string(i));
     }
 
-    RespValue request;
+    Common::Redis::RespValue request;
     makeBulkStringArray(request, request_strings);
 
-    std::vector<RespValue> tmp_expected_requests(num_gets);
+    std::vector<Common::Redis::RespValue> tmp_expected_requests(num_gets);
     expected_requests_.swap(tmp_expected_requests);
     pool_callbacks_.resize(num_gets);
     std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_gets);
@@ -363,7 +363,7 @@ public:
     handle_ = splitter_.makeRequest(request, callbacks_);
   }
 
-  std::vector<RespValue> expected_requests_;
+  std::vector<Common::Redis::RespValue> expected_requests_;
   std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
   std::vector<ConnPool::MockPoolRequest> pool_requests_;
 };
@@ -374,22 +374,22 @@ TEST_F(RedisMGETCommandHandlerTest, Normal) {
   setup(2, {});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Array);
-  std::vector<RespValue> elements(2);
-  elements[0].type(RespType::BulkString);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(2);
+  elements[0].type(Common::Redis::RespType::BulkString);
   elements[0].asString() = "response";
-  elements[1].type(RespType::BulkString);
+  elements[1].type(Common::Redis::RespType::BulkString);
   elements[1].asString() = "5";
   expected_response.asArray().swap(elements);
 
-  RespValuePtr response2(new RespValue());
-  response2->type(RespType::BulkString);
+  Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
+  response2->type(Common::Redis::RespType::BulkString);
   response2->asString() = "5";
   pool_callbacks_[1]->onResponse(std::move(response2));
 
-  RespValuePtr response1(new RespValue());
-  response1->type(RespType::BulkString);
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  response1->type(Common::Redis::RespType::BulkString);
   response1->asString() = "response";
   time_system_.setMonotonicTime(std::chrono::milliseconds(10));
   EXPECT_CALL(store_, deliverHistogramToSinks(
@@ -407,18 +407,18 @@ TEST_F(RedisMGETCommandHandlerTest, NormalWithNull) {
   setup(2, {});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Array);
-  std::vector<RespValue> elements(2);
-  elements[0].type(RespType::BulkString);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(2);
+  elements[0].type(Common::Redis::RespType::BulkString);
   elements[0].asString() = "response";
   expected_response.asArray().swap(elements);
 
-  RespValuePtr response2(new RespValue());
+  Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
   pool_callbacks_[1]->onResponse(std::move(response2));
 
-  RespValuePtr response1(new RespValue());
-  response1->type(RespType::BulkString);
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  response1->type(Common::Redis::RespType::BulkString);
   response1->asString() = "response";
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[0]->onResponse(std::move(response1));
@@ -427,12 +427,12 @@ TEST_F(RedisMGETCommandHandlerTest, NormalWithNull) {
 TEST_F(RedisMGETCommandHandlerTest, NoUpstreamHostForAll) {
   // No InSequence to avoid making setup() more complicated.
 
-  RespValue expected_response;
-  expected_response.type(RespType::Array);
-  std::vector<RespValue> elements(2);
-  elements[0].type(RespType::Error);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(2);
+  elements[0].type(Common::Redis::RespType::Error);
   elements[0].asString() = Response::get().NoUpstreamHost;
-  elements[1].type(RespType::Error);
+  elements[1].type(Common::Redis::RespType::Error);
   elements[1].asString() = Response::get().NoUpstreamHost;
   expected_response.asArray().swap(elements);
 
@@ -449,12 +449,12 @@ TEST_F(RedisMGETCommandHandlerTest, NoUpstreamHostForOne) {
   setup(2, {0});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Array);
-  std::vector<RespValue> elements(2);
-  elements[0].type(RespType::Error);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(2);
+  elements[0].type(Common::Redis::RespType::Error);
   elements[0].asString() = Response::get().NoUpstreamHost;
-  elements[1].type(RespType::Error);
+  elements[1].type(Common::Redis::RespType::Error);
   elements[1].asString() = Response::get().UpstreamFailure;
   expected_response.asArray().swap(elements);
 
@@ -470,19 +470,19 @@ TEST_F(RedisMGETCommandHandlerTest, Failure) {
   setup(2, {});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Array);
-  std::vector<RespValue> elements(2);
-  elements[0].type(RespType::BulkString);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(2);
+  elements[0].type(Common::Redis::RespType::BulkString);
   elements[0].asString() = "response";
-  elements[1].type(RespType::Error);
+  elements[1].type(Common::Redis::RespType::Error);
   elements[1].asString() = Response::get().UpstreamFailure;
   expected_response.asArray().swap(elements);
 
   pool_callbacks_[1]->onFailure();
 
-  RespValuePtr response1(new RespValue());
-  response1->type(RespType::BulkString);
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  response1->type(Common::Redis::RespType::BulkString);
   response1->asString() = "response";
   time_system_.setMonotonicTime(std::chrono::milliseconds(5));
   EXPECT_CALL(store_, deliverHistogramToSinks(
@@ -499,19 +499,19 @@ TEST_F(RedisMGETCommandHandlerTest, InvalidUpstreamResponse) {
   setup(2, {});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Array);
-  std::vector<RespValue> elements(2);
-  elements[0].type(RespType::Error);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(2);
+  elements[0].type(Common::Redis::RespType::Error);
   elements[0].asString() = Response::get().UpstreamProtocolError;
-  elements[1].type(RespType::Error);
+  elements[1].type(Common::Redis::RespType::Error);
   elements[1].asString() = Response::get().UpstreamFailure;
   expected_response.asArray().swap(elements);
 
   pool_callbacks_[1]->onFailure();
 
-  RespValuePtr response1(new RespValue());
-  response1->type(RespType::Integer);
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  response1->type(Common::Redis::RespType::Integer);
   response1->asInteger() = 5;
   time_system_.setMonotonicTime(std::chrono::milliseconds(10));
   EXPECT_CALL(store_, deliverHistogramToSinks(
@@ -544,10 +544,10 @@ public:
       request_strings.push_back(std::to_string(i));
     }
 
-    RespValue request;
+    Common::Redis::RespValue request;
     makeBulkStringArray(request, request_strings);
 
-    std::vector<RespValue> tmp_expected_requests(num_sets);
+    std::vector<Common::Redis::RespValue> tmp_expected_requests(num_sets);
     expected_requests_.swap(tmp_expected_requests);
     pool_callbacks_.resize(num_sets);
     std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_sets);
@@ -566,7 +566,7 @@ public:
     handle_ = splitter_.makeRequest(request, callbacks_);
   }
 
-  std::vector<RespValue> expected_requests_;
+  std::vector<Common::Redis::RespValue> expected_requests_;
   std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
   std::vector<ConnPool::MockPoolRequest> pool_requests_;
 };
@@ -577,17 +577,17 @@ TEST_F(RedisMSETCommandHandlerTest, Normal) {
   setup(2, {});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::SimpleString);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::SimpleString);
   expected_response.asString() = Response::get().OK;
 
-  RespValuePtr response2(new RespValue());
-  response2->type(RespType::SimpleString);
+  Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
+  response2->type(Common::Redis::RespType::SimpleString);
   response2->asString() = Response::get().OK;
   pool_callbacks_[1]->onResponse(std::move(response2));
 
-  RespValuePtr response1(new RespValue());
-  response1->type(RespType::SimpleString);
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  response1->type(Common::Redis::RespType::SimpleString);
   response1->asString() = Response::get().OK;
 
   time_system_.setMonotonicTime(std::chrono::milliseconds(10));
@@ -603,8 +603,8 @@ TEST_F(RedisMSETCommandHandlerTest, Normal) {
 TEST_F(RedisMSETCommandHandlerTest, NoUpstreamHostForAll) {
   // No InSequence to avoid making setup() more complicated.
 
-  RespValue expected_response;
-  expected_response.type(RespType::Error);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Error);
   expected_response.asString() = "finished with 2 error(s)";
 
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
@@ -620,12 +620,12 @@ TEST_F(RedisMSETCommandHandlerTest, NoUpstreamHostForOne) {
   setup(2, {0});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Error);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Error);
   expected_response.asString() = "finished with 1 error(s)";
 
-  RespValuePtr response2(new RespValue());
-  response2->type(RespType::SimpleString);
+  Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
+  response2->type(Common::Redis::RespType::SimpleString);
   response2->asString() = Response::get().OK;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[1]->onResponse(std::move(response2));
@@ -647,11 +647,11 @@ TEST_F(RedisMSETCommandHandlerTest, Cancel) {
 TEST_F(RedisMSETCommandHandlerTest, WrongNumberOfArgs) {
   InSequence s;
 
-  RespValue response;
-  response.type(RespType::Error);
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
   response.asString() = "wrong number of arguments for 'mset' command";
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
-  RespValue request;
+  Common::Redis::RespValue request;
   makeBulkStringArray(request, {"mset", "foo", "bar", "fizz"});
   EXPECT_EQ(nullptr, splitter_.makeRequest(request, callbacks_));
   EXPECT_EQ(1UL, store_.counter("redis.foo.command.mset.total").value());
@@ -667,10 +667,10 @@ public:
       request_strings.push_back(std::to_string(i));
     }
 
-    RespValue request;
+    Common::Redis::RespValue request;
     makeBulkStringArray(request, request_strings);
 
-    std::vector<RespValue> tmp_expected_requests(num_commands);
+    std::vector<Common::Redis::RespValue> tmp_expected_requests(num_commands);
     expected_requests_.swap(tmp_expected_requests);
     pool_callbacks_.resize(num_commands);
     std::vector<ConnPool::MockPoolRequest> tmp_pool_requests(num_commands);
@@ -689,7 +689,7 @@ public:
     handle_ = splitter_.makeRequest(request, callbacks_);
   }
 
-  std::vector<RespValue> expected_requests_;
+  std::vector<Common::Redis::RespValue> expected_requests_;
   std::vector<ConnPool::PoolCallbacks*> pool_callbacks_;
   std::vector<ConnPool::MockPoolRequest> pool_requests_;
 };
@@ -700,17 +700,17 @@ TEST_P(RedisSplitKeysSumResultHandlerTest, Normal) {
   setup(2, {});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Integer);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Integer);
   expected_response.asInteger() = 2;
 
-  RespValuePtr response2(new RespValue());
-  response2->type(RespType::Integer);
+  Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
+  response2->type(Common::Redis::RespType::Integer);
   response2->asInteger() = 1;
   pool_callbacks_[1]->onResponse(std::move(response2));
 
-  RespValuePtr response1(new RespValue());
-  response1->type(RespType::Integer);
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  response1->type(Common::Redis::RespType::Integer);
   response1->asInteger() = 1;
   time_system_.setMonotonicTime(std::chrono::milliseconds(10));
   EXPECT_CALL(
@@ -730,17 +730,17 @@ TEST_P(RedisSplitKeysSumResultHandlerTest, NormalOneZero) {
   setup(2, {});
   EXPECT_NE(nullptr, handle_);
 
-  RespValue expected_response;
-  expected_response.type(RespType::Integer);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Integer);
   expected_response.asInteger() = 1;
 
-  RespValuePtr response2(new RespValue());
-  response2->type(RespType::Integer);
+  Common::Redis::RespValuePtr response2(new Common::Redis::RespValue());
+  response2->type(Common::Redis::RespType::Integer);
   response2->asInteger() = 0;
   pool_callbacks_[1]->onResponse(std::move(response2));
 
-  RespValuePtr response1(new RespValue());
-  response1->type(RespType::Integer);
+  Common::Redis::RespValuePtr response1(new Common::Redis::RespValue());
+  response1->type(Common::Redis::RespType::Integer);
   response1->asInteger() = 1;
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[0]->onResponse(std::move(response1));
@@ -752,8 +752,8 @@ TEST_P(RedisSplitKeysSumResultHandlerTest, NormalOneZero) {
 TEST_P(RedisSplitKeysSumResultHandlerTest, NoUpstreamHostForAll) {
   // No InSequence to avoid making setup() more complicated.
 
-  RespValue expected_response;
-  expected_response.type(RespType::Error);
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Error);
   expected_response.asString() = "finished with 2 error(s)";
 
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
@@ -764,7 +764,7 @@ TEST_P(RedisSplitKeysSumResultHandlerTest, NoUpstreamHostForAll) {
 };
 
 INSTANTIATE_TEST_SUITE_P(RedisSplitKeysSumResultHandlerTest, RedisSplitKeysSumResultHandlerTest,
-                         testing::ValuesIn(SupportedCommands::hashMultipleSumResultCommands()));
+                         testing::ValuesIn(Common::Redis::SupportedCommands::hashMultipleSumResultCommands()));
 
 } // namespace CommandSplitter
 } // namespace RedisProxy

--- a/test/extensions/filters/network/redis_proxy/mocks.cc
+++ b/test/extensions/filters/network/redis_proxy/mocks.cc
@@ -15,17 +15,17 @@ namespace Extensions {
 namespace NetworkFilters {
 namespace RedisProxy {
 
-void PrintTo(const RespValue& value, std::ostream* os) { *os << value.toString(); }
+void PrintTo(const Common::Redis::RespValue& value, std::ostream* os) { *os << value.toString(); }
 
-void PrintTo(const RespValuePtr& value, std::ostream* os) { *os << value->toString(); }
+void PrintTo(const Common::Redis::RespValuePtr& value, std::ostream* os) { *os << value->toString(); }
 
-bool operator==(const RespValue& lhs, const RespValue& rhs) {
+bool operator==(const Common::Redis::RespValue& lhs, const Common::Redis::RespValue& rhs) {
   if (lhs.type() != rhs.type()) {
     return false;
   }
 
   switch (lhs.type()) {
-  case RespType::Array: {
+  case Common::Redis::RespType::Array: {
     if (lhs.asArray().size() != rhs.asArray().size()) {
       return false;
     }
@@ -37,15 +37,15 @@ bool operator==(const RespValue& lhs, const RespValue& rhs) {
 
     return equal;
   }
-  case RespType::SimpleString:
-  case RespType::BulkString:
-  case RespType::Error: {
+  case Common::Redis::RespType::SimpleString:
+  case Common::Redis::RespType::BulkString:
+  case Common::Redis::RespType::Error: {
     return lhs.asString() == rhs.asString();
   }
-  case RespType::Null: {
+  case Common::Redis::RespType::Null: {
     return true;
   }
-  case RespType::Integer: {
+  case Common::Redis::RespType::Integer: {
     return lhs.asInteger() == rhs.asInteger();
   }
   }
@@ -55,7 +55,7 @@ bool operator==(const RespValue& lhs, const RespValue& rhs) {
 
 MockEncoder::MockEncoder() {
   ON_CALL(*this, encode(_, _))
-      .WillByDefault(Invoke([this](const RespValue& value, Buffer::Instance& out) -> void {
+      .WillByDefault(Invoke([this](const Common::Redis::RespValue& value, Buffer::Instance& out) -> void {
         real_encoder_.encode(value, out);
       }));
 }

--- a/test/extensions/filters/network/redis_proxy/mocks.h
+++ b/test/extensions/filters/network/redis_proxy/mocks.h
@@ -4,7 +4,7 @@
 #include <list>
 #include <string>
 
-#include "extensions/filters/network/redis_proxy/codec_impl.h"
+#include "extensions/filters/network/common/redis/codec_impl.h"
 #include "extensions/filters/network/redis_proxy/command_splitter.h"
 #include "extensions/filters/network/redis_proxy/conn_pool.h"
 
@@ -18,25 +18,25 @@ namespace NetworkFilters {
 namespace RedisProxy {
 
 /**
- * Pretty print const RespValue& value
+ * Pretty print const Common::Redis::RespValue& value
  */
 
-void PrintTo(const RespValue& value, std::ostream* os);
-void PrintTo(const RespValuePtr& value, std::ostream* os);
-bool operator==(const RespValue& lhs, const RespValue& rhs);
+void PrintTo(const Common::Redis::RespValue& value, std::ostream* os);
+void PrintTo(const Common::Redis::RespValuePtr& value, std::ostream* os);
+bool operator==(const Common::Redis::RespValue& lhs, const Common::Redis::RespValue& rhs);
 
-class MockEncoder : public Encoder {
+class MockEncoder : public Common::Redis::Encoder {
 public:
   MockEncoder();
   ~MockEncoder();
 
-  MOCK_METHOD2(encode, void(const RespValue& value, Buffer::Instance& out));
+  MOCK_METHOD2(encode, void(const Common::Redis::RespValue& value, Buffer::Instance& out));
 
 private:
-  EncoderImpl real_encoder_;
+  Common::Redis::EncoderImpl real_encoder_;
 };
 
-class MockDecoder : public Decoder {
+class MockDecoder : public Common::Redis::Decoder {
 public:
   MockDecoder();
   ~MockDecoder();
@@ -71,7 +71,7 @@ public:
 
   MOCK_METHOD1(addConnectionCallbacks, void(Network::ConnectionCallbacks& callbacks));
   MOCK_METHOD0(close, void());
-  MOCK_METHOD2(makeRequest, PoolRequest*(const RespValue& request, PoolCallbacks& callbacks));
+  MOCK_METHOD2(makeRequest, PoolRequest*(const Common::Redis::RespValue& request, PoolCallbacks& callbacks));
 
   std::list<Network::ConnectionCallbacks*> callbacks_;
 };
@@ -89,9 +89,9 @@ public:
   MockPoolCallbacks();
   ~MockPoolCallbacks();
 
-  void onResponse(RespValuePtr&& value) override { onResponse_(value); }
+  void onResponse(Common::Redis::RespValuePtr&& value) override { onResponse_(value); }
 
-  MOCK_METHOD1(onResponse_, void(RespValuePtr& value));
+  MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
   MOCK_METHOD0(onFailure, void());
 };
 
@@ -100,7 +100,7 @@ public:
   MockInstance();
   ~MockInstance();
 
-  MOCK_METHOD3(makeRequest, PoolRequest*(const std::string& hash_key, const RespValue& request,
+  MOCK_METHOD3(makeRequest, PoolRequest*(const std::string& hash_key, const Common::Redis::RespValue& request,
                                          PoolCallbacks& callbacks));
 };
 
@@ -121,9 +121,9 @@ public:
   MockSplitCallbacks();
   ~MockSplitCallbacks();
 
-  void onResponse(RespValuePtr&& value) override { onResponse_(value); }
+  void onResponse(Common::Redis::RespValuePtr&& value) override { onResponse_(value); }
 
-  MOCK_METHOD1(onResponse_, void(RespValuePtr& value));
+  MOCK_METHOD1(onResponse_, void(Common::Redis::RespValuePtr& value));
 };
 
 class MockInstance : public Instance {
@@ -131,11 +131,11 @@ public:
   MockInstance();
   ~MockInstance();
 
-  SplitRequestPtr makeRequest(const RespValue& request, SplitCallbacks& callbacks) override {
+  SplitRequestPtr makeRequest(const Common::Redis::RespValue& request, SplitCallbacks& callbacks) override {
     return SplitRequestPtr{makeRequest_(request, callbacks)};
   }
 
-  MOCK_METHOD2(makeRequest_, SplitRequest*(const RespValue& request, SplitCallbacks& callbacks));
+  MOCK_METHOD2(makeRequest_, SplitRequest*(const Common::Redis::RespValue& request, SplitCallbacks& callbacks));
 };
 
 } // namespace CommandSplitter


### PR DESCRIPTION
This PR moves the Redis codec and supported commands into their own library separate from the existing `redis_proxy`, so that they can be re-used by a separate `redis_cluster_proxy`. The codec test is moved as well. There are some mocks, including for the == operator for some of stuff in the codec, and the inputs for the mocks are properly namespaced *I think*.

After the refactor the `common/redis` and `redis_proxy` look as follows- before there was no `common/redis` so I've omitted that:

```
  1       ▾ network/
  2         ▸ client_ssl_auth/
  3         ▾ common/
  4           ▾ redis/
  5               BUILD
  6               codec.h
  7               codec_impl.cc
  8               codec_impl.h
  9               supported_commands.h
 10             BUILD
 11             factory_base.h
 12         ▸ dubbo_proxy/
 13         ▸ echo/
 14         ▾ redis_proxy/
 15             BUILD
 16             command_splitter.h
 17             ...
 18             proxy_filter.cc
 19             proxy_filter.h
 20         ▸ sni_cluster/
 21         ▸ tcp_proxy/
 22         ▸ thrift_proxy/
 23           BUILD
 24           well_known_names.h
 25     ▸ grpc_credentials/
 26     ▸ health_checkers/
```

The sources all compile fine, and the common redis command and mock test targets work fine. However, when it comes to testing some of the redis proxy classes, particularly using the == operator, we get errors.

In particular, the test for the command splitter fails due to the operator overload not being picked up. The command is `bazel test //test/extensions/filters/network/redis_proxy:command_splitter_impl_test`, with output:

```
  1 INFO: Found 1 test target...
  2 ERROR: /home/nflacco/src/smaller-envoy/test/extensions/filters/network/redis_proxy/BUILD:16:1: C++ compilation of rule '//test/extensions/filters/network/redis_proxy:command_splitter_impl_test_lib' failed (Exit 1) envoy_cc_wrapp
  3 er failed: error executing command /home/nflacco/.cache/bazel/_bazel_nflacco/803675aa75e9a13235a7fe5504cd07c0/external/local_config_cc/extra_tools/envoy_cc_wrapper -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-param
  4 eter ... (remaining 296 argument(s) skipped)
  5
  6 Use --sandbox_debug to see verbose messages from the sandbox
  7 In file included from test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc:13:0:
  8 ./test/mocks/common.h: In instantiation of 'bool Envoy::PointeesEqMatcherP<rhs_type>::gmock_Impl<arg_type>::MatchAndExplain(typename testing::internal::ConstRef<arg_type>::type, testing::MatchResultListener*) const [with arg_typ
  9 e = std::unique_ptr<Envoy::Extensions::NetworkFilters::Common::Redis::RespValue>&; rhs_type = Envoy::Extensions::NetworkFilters::Common::Redis::RespValue*; typename testing::internal::ConstRef<arg_type>::type = std::unique_ptr<E
 10 nvoy::Extensions::NetworkFilters::Common::Redis::RespValue>&]':
 11 test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc:773:1:   required from here
 12 ./test/mocks/common.h:28:15: error: no match for 'operator==' (operand types are 'Envoy::Extensions::NetworkFilters::Common::Redis::RespValue' and 'Envoy::Extensions::NetworkFilters::Common::Redis::RespValue')
 13    return *arg == *rhs;
 14           ~~~~~^~~~~~~
 15 ./test/mocks/common.h:89:13: note: candidate: bool Envoy::operator==(const char*, const Envoy::StringViewSaver&)
 16  inline bool operator==(const char* str, const StringViewSaver& saver) {
 17              ^~~~~~~~
 18 ./test/mocks/common.h:89:13: note:   no known conversion for argument 1 from 'Envoy::Extensions::NetworkFilters::Common::Redis::RespValue' to 'const char*'
 19 ./test/mocks/common.h:93:13: note: candidate: bool Envoy::operator==(const Envoy::StringViewSaver&, const char*)
 20  inline bool operator==(const StringViewSaver& saver, const char* str) {
 21              ^~~~~~~~
 22 ./test/mocks/common.h:93:13: note:   no known conversion for argument 1 from 'Envoy::Extensions::NetworkFilters::Common::Redis::RespValue' to 'const Envoy::StringViewSaver&'
```