### PR TITLE
WIP: RedisCommandStats singleton

### DIFF
--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -205,15 +205,15 @@ public:
    */
   virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                            const Config& config,
-                           const RedisCommandStatsSharedPtr& redis_command_stats,
+                           const RedisCommandStatsSharedPtr redis_command_stats,
                            Stats::Scope& scope, const std::string& auth_password) PURE;
 
   /**
   * Get shared Redis command stats object; used for all Redis clients.
-  * @param symbol_table supplies a location to store StatNames
-  * @return RedisCommandStats the shared stats object
+  * @param scope supplies a stats scope
+  * @return RedisCommandStatsSharedPtr pointer to the shared stats object
   */
-  virtual const RedisCommandStatsSharedPtr& getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) PURE;
+  virtual const RedisCommandStatsSharedPtr getOrCreateRedisCommandStats(Stats::Scope& scope) PURE;
 };
 
 } // namespace Client

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -207,6 +207,13 @@ public:
                            const Config& config,
                            const RedisCommandStatsSharedPtr& redis_command_stats,
                            Stats::Scope& scope, const std::string& auth_password) PURE;
+
+  /**
+  * Get shared Redis command stats object; used for all Redis clients.
+  * @param symbol_table supplies a location to store StatNames
+  * @return RedisCommandStats the shared stats object
+  */
+  virtual const RedisCommandStats& getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) PURE;
 };
 
 } // namespace Client

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -205,7 +205,7 @@ public:
    */
   virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                            const Config& config,
-                           const RedisCommandStats& redis_command_stats,
+                           const RedisCommandStatsSharedPtr& redis_command_stats,
                            Stats::Scope& scope, const std::string& auth_password) PURE;
 
   /**
@@ -213,7 +213,7 @@ public:
   * @param symbol_table supplies a location to store StatNames
   * @return RedisCommandStats the shared stats object
   */
-  virtual const RedisCommandStats& getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) PURE;
+  virtual const RedisCommandStatsSharedPtr& getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) PURE;
 };
 
 } // namespace Client

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -209,10 +209,10 @@ public:
                            Stats::Scope& scope, const std::string& auth_password) PURE;
 
   /**
-  * Get shared Redis command stats object; used for all Redis clients.
-  * @param scope supplies a stats scope
-  * @return RedisCommandStatsSharedPtr pointer to the shared stats object
-  */
+   * Get shared Redis command stats object; used for all Redis clients.
+   * @param scope supplies a stats scope
+   * @return RedisCommandStatsSharedPtr pointer to the shared stats object
+   */
   virtual const RedisCommandStatsSharedPtr getOrCreateRedisCommandStats(Stats::Scope& scope) PURE;
 };
 

--- a/source/extensions/filters/network/common/redis/client.h
+++ b/source/extensions/filters/network/common/redis/client.h
@@ -205,7 +205,7 @@ public:
    */
   virtual ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                            const Config& config,
-                           const RedisCommandStatsSharedPtr& redis_command_stats,
+                           const RedisCommandStats& redis_command_stats,
                            Stats::Scope& scope, const std::string& auth_password) PURE;
 
   /**

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -56,7 +56,7 @@ ConfigImpl::ConfigImpl(
 ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                              EncoderPtr&& encoder, DecoderFactory& decoder_factory,
                              const Config& config,
-                             const RedisCommandStatsSharedPtr& redis_command_stats,
+                             const RedisCommandStatsSharedPtr redis_command_stats,
                              Stats::Scope& scope) {
   auto client = std::make_unique<ClientImpl>(host, dispatcher, std::move(encoder), decoder_factory,
                                              config, redis_command_stats, scope);
@@ -70,7 +70,7 @@ ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatche
 
 ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                        EncoderPtr&& encoder, DecoderFactory& decoder_factory, const Config& config,
-                       const RedisCommandStatsSharedPtr& redis_command_stats, Stats::Scope& scope)
+                       const RedisCommandStatsSharedPtr redis_command_stats, Stats::Scope& scope)
     : host_(host), encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)),
       config_(config),
       connect_or_op_timer_(dispatcher.createTimer([this]() { onConnectOrOpTimeout(); })),
@@ -303,7 +303,7 @@ ClientFactoryImpl ClientFactoryImpl::instance_;
 
 ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
                                     Event::Dispatcher& dispatcher, const Config& config,
-                                    const RedisCommandStatsSharedPtr& redis_command_stats,
+                                    const RedisCommandStatsSharedPtr redis_command_stats,
                                     Stats::Scope& scope, const std::string& auth_password) {
   ClientPtr client = ClientImpl::create(host, dispatcher, EncoderPtr{new EncoderImpl()},
                                         decoder_factory_, config, redis_command_stats, scope);

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -56,7 +56,7 @@ ConfigImpl::ConfigImpl(
 ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                              EncoderPtr&& encoder, DecoderFactory& decoder_factory,
                              const Config& config,
-                             const RedisCommandStatsSharedPtr& redis_command_stats,
+                             const RedisCommandStats& redis_command_stats,
                              Stats::Scope& scope) {
   auto client = std::make_unique<ClientImpl>(host, dispatcher, std::move(encoder), decoder_factory,
                                              config, redis_command_stats, scope);
@@ -70,7 +70,7 @@ ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatche
 
 ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                        EncoderPtr&& encoder, DecoderFactory& decoder_factory, const Config& config,
-                       const RedisCommandStatsSharedPtr& redis_command_stats, Stats::Scope& scope)
+                       const RedisCommandStats& redis_command_stats, Stats::Scope& scope)
     : host_(host), encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)),
       config_(config),
       connect_or_op_timer_(dispatcher.createTimer([this]() { onConnectOrOpTimeout(); })),
@@ -303,7 +303,7 @@ ClientFactoryImpl ClientFactoryImpl::instance_;
 
 ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
                                     Event::Dispatcher& dispatcher, const Config& config,
-                                    const RedisCommandStatsSharedPtr& redis_command_stats,
+                                    const RedisCommandStats& redis_command_stats,
                                     Stats::Scope& scope, const std::string& auth_password) {
   ClientPtr client = ClientImpl::create(host, dispatcher, EncoderPtr{new EncoderImpl()},
                                         decoder_factory_, config, redis_command_stats, scope);

--- a/source/extensions/filters/network/common/redis/client_impl.cc
+++ b/source/extensions/filters/network/common/redis/client_impl.cc
@@ -56,7 +56,7 @@ ConfigImpl::ConfigImpl(
 ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                              EncoderPtr&& encoder, DecoderFactory& decoder_factory,
                              const Config& config,
-                             const RedisCommandStats& redis_command_stats,
+                             const RedisCommandStatsSharedPtr& redis_command_stats,
                              Stats::Scope& scope) {
   auto client = std::make_unique<ClientImpl>(host, dispatcher, std::move(encoder), decoder_factory,
                                              config, redis_command_stats, scope);
@@ -70,7 +70,7 @@ ClientPtr ClientImpl::create(Upstream::HostConstSharedPtr host, Event::Dispatche
 
 ClientImpl::ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                        EncoderPtr&& encoder, DecoderFactory& decoder_factory, const Config& config,
-                       const RedisCommandStats& redis_command_stats, Stats::Scope& scope)
+                       const RedisCommandStatsSharedPtr& redis_command_stats, Stats::Scope& scope)
     : host_(host), encoder_(std::move(encoder)), decoder_(decoder_factory.create(*this)),
       config_(config),
       connect_or_op_timer_(dispatcher.createTimer([this]() { onConnectOrOpTimeout(); })),
@@ -108,11 +108,11 @@ PoolRequest* ClientImpl::makeRequest(const RespValue& request, ClientCallbacks& 
   Stats::StatName command;
   if (config_.enableCommandStats()) {
     // Only lowercase command and get StatName if we enable command stats
-    command = redis_command_stats_.getCommandFromRequest(request);
-    redis_command_stats_.updateStatsTotal(scope_, command);
+    command = redis_command_stats_->getCommandFromRequest(request);
+    redis_command_stats_->updateStatsTotal(scope_, command);
   } else {
     // If disabled, we use a placeholder stat name "unused" that is not used
-    command = redis_command_stats_.getUnusedStatName();
+    command = redis_command_stats_->getUnusedStatName();
   }
 
   pending_requests_.emplace_back(*this, callbacks, command);
@@ -210,7 +210,7 @@ void ClientImpl::onRespValue(RespValuePtr&& value) {
 
   if (config_.enableCommandStats()) {
     bool success = !canceled && (value->type() != Common::Redis::RespType::Error);
-    redis_command_stats_.updateStats(scope_, request.command_, success);
+    redis_command_stats_->updateStats(scope_, request.command_, success);
     request.command_request_timer_->complete();
   }
   request.aggregate_request_timer_->complete();
@@ -261,10 +261,10 @@ void ClientImpl::onRespValue(RespValuePtr&& value) {
 ClientImpl::PendingRequest::PendingRequest(ClientImpl& parent, ClientCallbacks& callbacks,
                                            Stats::StatName command)
     : parent_(parent), callbacks_(callbacks), command_{command},
-      aggregate_request_timer_(parent_.redis_command_stats_.createAggregateTimer(
+      aggregate_request_timer_(parent_.redis_command_stats_->createAggregateTimer(
           parent_.scope_, parent_.time_source_)) {
   if (parent_.config_.enableCommandStats()) {
-    command_request_timer_ = parent_.redis_command_stats_.createCommandTimer(
+    command_request_timer_ = parent_.redis_command_stats_->createCommandTimer(
         parent_.scope_, command_, parent_.time_source_);
   }
   parent.host_->cluster().stats().upstream_rq_total_.inc();
@@ -303,7 +303,7 @@ ClientFactoryImpl ClientFactoryImpl::instance_;
 
 ClientPtr ClientFactoryImpl::create(Upstream::HostConstSharedPtr host,
                                     Event::Dispatcher& dispatcher, const Config& config,
-                                    const RedisCommandStats& redis_command_stats,
+                                    const RedisCommandStatsSharedPtr& redis_command_stats,
                                     Stats::Scope& scope, const std::string& auth_password) {
   ClientPtr client = ClientImpl::create(host, dispatcher, EncoderPtr{new EncoderImpl()},
                                         decoder_factory_, config, redis_command_stats, scope);

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -71,12 +71,12 @@ public:
   static ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                           EncoderPtr&& encoder, DecoderFactory& decoder_factory,
                           const Config& config,
-                          const RedisCommandStatsSharedPtr& redis_command_stats,
+                          const RedisCommandStatsSharedPtr redis_command_stats,
                           Stats::Scope& scope);
 
   ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher, EncoderPtr&& encoder,
              DecoderFactory& decoder_factory, const Config& config,
-             const RedisCommandStatsSharedPtr& redis_command_stats, Stats::Scope& scope);
+             const RedisCommandStatsSharedPtr redis_command_stats, Stats::Scope& scope);
   ~ClientImpl() override;
 
   // Client
@@ -142,7 +142,7 @@ private:
   bool connected_{};
   Event::TimerPtr flush_timer_;
   Envoy::TimeSource& time_source_;
-  const RedisCommandStatsSharedPtr& redis_command_stats_;
+  const RedisCommandStatsSharedPtr redis_command_stats_;
   Stats::Scope& scope_;
 };
 
@@ -150,10 +150,10 @@ class ClientFactoryImpl : public ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
   ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                   const Config& config, const RedisCommandStatsSharedPtr& redis_command_stats,
+                   const Config& config, const RedisCommandStatsSharedPtr redis_command_stats,
                    Stats::Scope& scope, const std::string& auth_password) override;
 
-  const RedisCommandStatsSharedPtr& getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) override {
+  const RedisCommandStatsSharedPtr getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) override {
     Thread::LockGuard lock(mutex_);
     if (redis_command_stats_ == nullptr) {
       redis_command_stats_ = std::make_shared<RedisCommandStats>(symbol_table, "upstream_commands");

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -71,12 +71,12 @@ public:
   static ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
                           EncoderPtr&& encoder, DecoderFactory& decoder_factory,
                           const Config& config,
-                          const RedisCommandStatsSharedPtr& redis_command_stats,
+                          const RedisCommandStats& redis_command_stats,
                           Stats::Scope& scope);
 
   ClientImpl(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher, EncoderPtr&& encoder,
              DecoderFactory& decoder_factory, const Config& config,
-             const RedisCommandStatsSharedPtr& redis_command_stats, Stats::Scope& scope);
+             const RedisCommandStats& redis_command_stats, Stats::Scope& scope);
   ~ClientImpl() override;
 
   // Client
@@ -142,7 +142,7 @@ private:
   bool connected_{};
   Event::TimerPtr flush_timer_;
   Envoy::TimeSource& time_source_;
-  const RedisCommandStatsSharedPtr redis_command_stats_;
+  const RedisCommandStats& redis_command_stats_;
   Stats::Scope& scope_;
 };
 
@@ -150,7 +150,7 @@ class ClientFactoryImpl : public ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
   ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                   const Config& config, const RedisCommandStatsSharedPtr& redis_command_stats,
+                   const Config& config, const RedisCommandStats& redis_command_stats,
                    Stats::Scope& scope, const std::string& auth_password) override;
 
   const RedisCommandStats& getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) override {

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -150,8 +150,7 @@ class ClientFactoryImpl : public ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
   ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                   const Config& config,
-                   const RedisCommandStatsSharedPtr redis_command_stats,
+                   const Config& config, const RedisCommandStatsSharedPtr redis_command_stats,
                    Stats::Scope& scope, const std::string& auth_password) override;
 
   const RedisCommandStatsSharedPtr getOrCreateRedisCommandStats(Stats::Scope& scope) override {
@@ -168,7 +167,8 @@ private:
   DecoderFactoryImpl decoder_factory_;
   RedisCommandStatsSharedPtr redis_command_stats_;
 
-  // A mutex is used to only create the stats object once, so it can be shared by discover, healthy check and the proxy      filter.
+  // A mutex is used to only create the stats object once, so it can be shared by discover, healthy
+  // check and the proxy      filter.
   mutable Thread::MutexBasicLockable mutex_;
 };
 

--- a/source/extensions/filters/network/common/redis/client_impl.h
+++ b/source/extensions/filters/network/common/redis/client_impl.h
@@ -150,13 +150,14 @@ class ClientFactoryImpl : public ClientFactory {
 public:
   // RedisProxy::ConnPool::ClientFactoryImpl
   ClientPtr create(Upstream::HostConstSharedPtr host, Event::Dispatcher& dispatcher,
-                   const Config& config, const RedisCommandStatsSharedPtr redis_command_stats,
+                   const Config& config,
+                   const RedisCommandStatsSharedPtr redis_command_stats,
                    Stats::Scope& scope, const std::string& auth_password) override;
 
-  const RedisCommandStatsSharedPtr getOrCreateRedisCommandStats(Stats::SymbolTable& symbol_table) override {
+  const RedisCommandStatsSharedPtr getOrCreateRedisCommandStats(Stats::Scope& scope) override {
     Thread::LockGuard lock(mutex_);
     if (redis_command_stats_ == nullptr) {
-      redis_command_stats_ = std::make_shared<RedisCommandStats>(symbol_table, "upstream_commands");
+      redis_command_stats_ = std::make_shared<RedisCommandStats>(scope, "upstream_commands");
     }
     return redis_command_stats_;
   }

--- a/source/extensions/filters/network/common/redis/redis_command_stats.cc
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.cc
@@ -10,8 +10,8 @@ namespace NetworkFilters {
 namespace Common {
 namespace Redis {
 
-RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table, const std::string& prefix)
-    : symbol_table_(symbol_table), stat_name_set_(symbol_table_.makeSet("Redis")),
+RedisCommandStats::RedisCommandStats(Stats::Scope& scope, const std::string& prefix)
+    : scope_(scope), stat_name_set_(scope.symbolTable().makeSet("Redis")),
       prefix_(stat_name_set_->add(prefix)),
       upstream_rq_time_(stat_name_set_->add("upstream_rq_time")),
       latency_(stat_name_set_->add("latency")), total_(stat_name_set_->add("total")),
@@ -34,7 +34,7 @@ RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table, const std
 
 Stats::Counter& RedisCommandStats::counter(Stats::Scope& scope,
                                            const Stats::StatNameVec& stat_names) const {
-  const Stats::SymbolTable::StoragePtr storage_ptr = symbol_table_.join(stat_names);
+  const Stats::SymbolTable::StoragePtr storage_ptr = scope_.symbolTable().join(stat_names);
   Stats::StatName full_stat_name = Stats::StatName(storage_ptr.get());
   return scope.counterFromStatName(full_stat_name);
 }
@@ -42,7 +42,7 @@ Stats::Counter& RedisCommandStats::counter(Stats::Scope& scope,
 Stats::Histogram& RedisCommandStats::histogram(Stats::Scope& scope,
                                                const Stats::StatNameVec& stat_names,
                                                Stats::Histogram::Unit unit) const {
-  const Stats::SymbolTable::StoragePtr storage_ptr = symbol_table_.join(stat_names);
+  const Stats::SymbolTable::StoragePtr storage_ptr = scope_.symbolTable().join(stat_names);
   Stats::StatName full_stat_name = Stats::StatName(storage_ptr.get());
   return scope.histogramFromStatName(full_stat_name, unit);
 }

--- a/source/extensions/filters/network/common/redis/redis_command_stats.cc
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.cc
@@ -33,7 +33,7 @@ RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table, const std
 }
 
 Stats::Counter& RedisCommandStats::counter(Stats::Scope& scope,
-                                           const Stats::StatNameVec& stat_names) {
+                                           const Stats::StatNameVec& stat_names) const {
   const Stats::SymbolTable::StoragePtr storage_ptr = symbol_table_.join(stat_names);
   Stats::StatName full_stat_name = Stats::StatName(storage_ptr.get());
   return scope.counterFromStatName(full_stat_name);
@@ -41,7 +41,7 @@ Stats::Counter& RedisCommandStats::counter(Stats::Scope& scope,
 
 Stats::Histogram& RedisCommandStats::histogram(Stats::Scope& scope,
                                                const Stats::StatNameVec& stat_names,
-                                               Stats::Histogram::Unit unit) {
+                                               Stats::Histogram::Unit unit) const {
   const Stats::SymbolTable::StoragePtr storage_ptr = symbol_table_.join(stat_names);
   Stats::StatName full_stat_name = Stats::StatName(storage_ptr.get());
   return scope.histogramFromStatName(full_stat_name, unit);
@@ -49,20 +49,20 @@ Stats::Histogram& RedisCommandStats::histogram(Stats::Scope& scope,
 
 Stats::TimespanPtr RedisCommandStats::createCommandTimer(Stats::Scope& scope,
                                                          Stats::StatName command,
-                                                         Envoy::TimeSource& time_source) {
+                                                         Envoy::TimeSource& time_source) const {
   return std::make_unique<Stats::HistogramCompletableTimespanImpl>(
       histogram(scope, {prefix_, command, latency_}, Stats::Histogram::Unit::Microseconds),
       time_source);
 }
 
 Stats::TimespanPtr RedisCommandStats::createAggregateTimer(Stats::Scope& scope,
-                                                           Envoy::TimeSource& time_source) {
+                                                           Envoy::TimeSource& time_source) const {
   return std::make_unique<Stats::HistogramCompletableTimespanImpl>(
       histogram(scope, {prefix_, upstream_rq_time_}, Stats::Histogram::Unit::Microseconds),
       time_source);
 }
 
-Stats::StatName RedisCommandStats::getCommandFromRequest(const RespValue& request) {
+Stats::StatName RedisCommandStats::getCommandFromRequest(const RespValue& request) const {
   // Get command from RespValue
   switch (request.type()) {
   case RespType::Array:
@@ -78,12 +78,12 @@ Stats::StatName RedisCommandStats::getCommandFromRequest(const RespValue& reques
   }
 }
 
-void RedisCommandStats::updateStatsTotal(Stats::Scope& scope, Stats::StatName command) {
+void RedisCommandStats::updateStatsTotal(Stats::Scope& scope, Stats::StatName command) const {
   counter(scope, {prefix_, command, total_}).inc();
 }
 
 void RedisCommandStats::updateStats(Stats::Scope& scope, Stats::StatName command,
-                                    const bool success) {
+                                    const bool success) const {
   if (success) {
     counter(scope, {prefix_, command, success_}).inc();
   } else {

--- a/source/extensions/filters/network/common/redis/redis_command_stats.h
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.h
@@ -24,21 +24,24 @@ public:
   // TODO (@FAYiEKcbD0XFqF2QK2E4viAHg8rMm2VbjYKdjTg): Use Singleton to manage a single
   // RedisCommandStats on the client factory so that it can be used for proxy filter, discovery and
   // health check.
+
+  // TODO (@FAYiEKcbD0XFqF2QK2E4viAHg8rMm2VbjYKdjTg): Figure out how to make sure command splitter
+  // behaves correctly wrt redis command stats
   static std::shared_ptr<RedisCommandStats>
   createRedisCommandStats(Stats::SymbolTable& symbol_table) {
     return std::make_shared<Common::Redis::RedisCommandStats>(symbol_table, "upstream_commands");
   }
 
-  Stats::Counter& counter(Stats::Scope& scope, const Stats::StatNameVec& stat_names);
+  Stats::Counter& counter(Stats::Scope& scope, const Stats::StatNameVec& stat_names) const;
   Stats::Histogram& histogram(Stats::Scope& scope, const Stats::StatNameVec& stat_names,
-                              Stats::Histogram::Unit unit);
+                              Stats::Histogram::Unit unit) const;
   Stats::TimespanPtr createCommandTimer(Stats::Scope& scope, Stats::StatName command,
-                                        Envoy::TimeSource& time_source);
-  Stats::TimespanPtr createAggregateTimer(Stats::Scope& scope, Envoy::TimeSource& time_source);
-  Stats::StatName getCommandFromRequest(const RespValue& request);
-  void updateStatsTotal(Stats::Scope& scope, Stats::StatName command);
-  void updateStats(Stats::Scope& scope, Stats::StatName command, const bool success);
-  Stats::StatName getUnusedStatName() { return unused_metric_; }
+                                        Envoy::TimeSource& time_source) const;
+  Stats::TimespanPtr createAggregateTimer(Stats::Scope& scope, Envoy::TimeSource& time_source) const;
+  Stats::StatName getCommandFromRequest(const RespValue& request) const;
+  void updateStatsTotal(Stats::Scope& scope, Stats::StatName command) const;
+  void updateStats(Stats::Scope& scope, Stats::StatName command, const bool success) const;
+  Stats::StatName getUnusedStatName() const { return unused_metric_; }
 
 private:
   Stats::SymbolTable& symbol_table_;

--- a/source/extensions/filters/network/common/redis/redis_command_stats.h
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.h
@@ -21,14 +21,9 @@ class RedisCommandStats {
 public:
   RedisCommandStats(Stats::Scope& scope, const std::string& prefix);
 
-  // TODO (@FAYiEKcbD0XFqF2QK2E4viAHg8rMm2VbjYKdjTg): Use Singleton to manage a single
-  // RedisCommandStats on the client factory so that it can be used for proxy filter, discovery and
-  // health check.
-
   // TODO (@FAYiEKcbD0XFqF2QK2E4viAHg8rMm2VbjYKdjTg): Figure out how to make sure command splitter
-  // behaves correctly wrt redis command stats
-  static std::shared_ptr<RedisCommandStats>
-  createRedisCommandStats(Stats::Scope& scope) {
+  // behaves correctly with respect to redis command stats
+  static std::shared_ptr<RedisCommandStats> createRedisCommandStats(Stats::Scope& scope) {
     return std::make_shared<Common::Redis::RedisCommandStats>(scope, "upstream_commands");
   }
 
@@ -37,7 +32,8 @@ public:
                               Stats::Histogram::Unit unit) const;
   Stats::TimespanPtr createCommandTimer(Stats::Scope& scope, Stats::StatName command,
                                         Envoy::TimeSource& time_source) const;
-  Stats::TimespanPtr createAggregateTimer(Stats::Scope& scope, Envoy::TimeSource& time_source) const;
+  Stats::TimespanPtr createAggregateTimer(Stats::Scope& scope,
+                                          Envoy::TimeSource& time_source) const;
   Stats::StatName getCommandFromRequest(const RespValue& request) const;
   void updateStatsTotal(Stats::Scope& scope, Stats::StatName command) const;
   void updateStats(Stats::Scope& scope, Stats::StatName command, const bool success) const;

--- a/source/extensions/filters/network/common/redis/redis_command_stats.h
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.h
@@ -57,8 +57,7 @@ private:
   const Stats::StatName unknown_metric_;
   const ToLowerTable to_lower_table_;
 };
-using RedisCommandStatsSharedPtr = std::shared_ptr<RedisCommandStats>; // TODO: Remove
-using RedisCommandStatsUniquePtr = std::unique_ptr<RedisCommandStats>;
+using RedisCommandStatsSharedPtr = std::shared_ptr<RedisCommandStats>;
 
 } // namespace Redis
 } // namespace Common

--- a/source/extensions/filters/network/common/redis/redis_command_stats.h
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.h
@@ -19,7 +19,7 @@ namespace Redis {
 
 class RedisCommandStats {
 public:
-  RedisCommandStats(Stats::SymbolTable& symbol_table, const std::string& prefix);
+  RedisCommandStats(Stats::Scope& scope, const std::string& prefix);
 
   // TODO (@FAYiEKcbD0XFqF2QK2E4viAHg8rMm2VbjYKdjTg): Use Singleton to manage a single
   // RedisCommandStats on the client factory so that it can be used for proxy filter, discovery and
@@ -28,8 +28,8 @@ public:
   // TODO (@FAYiEKcbD0XFqF2QK2E4viAHg8rMm2VbjYKdjTg): Figure out how to make sure command splitter
   // behaves correctly wrt redis command stats
   static std::shared_ptr<RedisCommandStats>
-  createRedisCommandStats(Stats::SymbolTable& symbol_table) {
-    return std::make_shared<Common::Redis::RedisCommandStats>(symbol_table, "upstream_commands");
+  createRedisCommandStats(Stats::Scope& scope) {
+    return std::make_shared<Common::Redis::RedisCommandStats>(scope, "upstream_commands");
   }
 
   Stats::Counter& counter(Stats::Scope& scope, const Stats::StatNameVec& stat_names) const;
@@ -44,7 +44,7 @@ public:
   Stats::StatName getUnusedStatName() const { return unused_metric_; }
 
 private:
-  Stats::SymbolTable& symbol_table_;
+  Stats::Scope& scope_;
   Stats::StatNameSetPtr stat_name_set_;
   const Stats::StatName prefix_;
   const Stats::StatName upstream_rq_time_;

--- a/source/extensions/filters/network/common/redis/redis_command_stats.h
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.h
@@ -54,7 +54,8 @@ private:
   const Stats::StatName unknown_metric_;
   const ToLowerTable to_lower_table_;
 };
-using RedisCommandStatsSharedPtr = std::shared_ptr<RedisCommandStats>;
+using RedisCommandStatsSharedPtr = std::shared_ptr<RedisCommandStats>; // TODO: Remove
+using RedisCommandStatsUniquePtr = std::unique_ptr<RedisCommandStats>;
 
 } // namespace Redis
 } // namespace Common

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -78,7 +78,7 @@ public:
     EXPECT_CALL(*upstream_connection_, connect());
     EXPECT_CALL(*upstream_connection_, noDelay(true));
 
-    const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
+    const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_);
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
                                  *config_, redis_command_stats, stats_);
@@ -1187,7 +1187,7 @@ TEST(RedisClientFactoryImplTest, Basic) {
   NiceMock<Event::MockDispatcher> dispatcher;
   ConfigImpl config(createConnPoolSettings());
   Stats::IsolatedStoreImpl stats_;
-  const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
+  const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_); // This shouldn't work either
   const std::string auth_password;
   ClientPtr client =
       factory.create(host, dispatcher, config, redis_command_stats, stats_, auth_password);

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -78,7 +78,7 @@ public:
     EXPECT_CALL(*upstream_connection_, connect());
     EXPECT_CALL(*upstream_connection_, noDelay(true));
 
-    const RedisCommandStatsSharedPtr& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
+    const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
                                  *config_, redis_command_stats, stats_);
@@ -1187,7 +1187,7 @@ TEST(RedisClientFactoryImplTest, Basic) {
   NiceMock<Event::MockDispatcher> dispatcher;
   ConfigImpl config(createConnPoolSettings());
   Stats::IsolatedStoreImpl stats_;
-  const RedisCommandStatsSharedPtr& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
+  const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
   const std::string auth_password;
   ClientPtr client =
       factory.create(host, dispatcher, config, redis_command_stats, stats_, auth_password);

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -78,7 +78,7 @@ public:
     EXPECT_CALL(*upstream_connection_, connect());
     EXPECT_CALL(*upstream_connection_, noDelay(true));
 
-    auto redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
+    const RedisCommandStats& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
                                  *config_, redis_command_stats, stats_);
@@ -1185,8 +1185,7 @@ TEST(RedisClientFactoryImplTest, Basic) {
   NiceMock<Event::MockDispatcher> dispatcher;
   ConfigImpl config(createConnPoolSettings());
   Stats::IsolatedStoreImpl stats_;
-  auto redis_command_stats =
-      Common::Redis::RedisCommandStats::createRedisCommandStats(stats_.symbolTable());
+  const RedisCommandStats& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
   const std::string auth_password;
   ClientPtr client =
       factory.create(host, dispatcher, config, redis_command_stats, stats_, auth_password);

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -78,7 +78,8 @@ public:
     EXPECT_CALL(*upstream_connection_, connect());
     EXPECT_CALL(*upstream_connection_, noDelay(true));
 
-    const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_);
+    const RedisCommandStatsSharedPtr redis_command_stats =
+        Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_);
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
                                  *config_, redis_command_stats, stats_);
@@ -432,7 +433,6 @@ TEST_F(RedisClientImplTest, CommandStatsEnabledTwoRequests) {
   Common::Redis::RespValue request1;
   initializeRedisSimpleCommand(&request1, get_command, "foo");
   MockClientCallbacks callbacks1;
-
 
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
   EXPECT_CALL(*flush_timer_, enabled()).WillOnce(Return(false));
@@ -1187,7 +1187,9 @@ TEST(RedisClientFactoryImplTest, Basic) {
   NiceMock<Event::MockDispatcher> dispatcher;
   ConfigImpl config(createConnPoolSettings());
   Stats::IsolatedStoreImpl stats_;
-  const RedisCommandStatsSharedPtr redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_); // This shouldn't work either
+  const RedisCommandStatsSharedPtr redis_command_stats =
+      Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(
+          stats_); // This shouldn't work either
   const std::string auth_password;
   ClientPtr client =
       factory.create(host, dispatcher, config, redis_command_stats, stats_, auth_password);

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -78,11 +78,10 @@ public:
     EXPECT_CALL(*upstream_connection_, connect());
     EXPECT_CALL(*upstream_connection_, noDelay(true));
 
-    redis_command_stats_ =
-        Common::Redis::RedisCommandStats::createRedisCommandStats(stats_.symbolTable());
+    auto redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
-                                 *config_, redis_command_stats_, stats_);
+                                 *config_, redis_command_stats, stats_);
     EXPECT_EQ(1UL, host_->cluster_.stats_.upstream_cx_total_.value());
     EXPECT_EQ(1UL, host_->stats_.cx_total_.value());
     EXPECT_EQ(false, client_->active());
@@ -143,7 +142,6 @@ public:
   ClientPtr client_;
   NiceMock<Stats::MockIsolatedStatsStore> stats_;
   Stats::ScopePtr stats_scope_;
-  Common::Redis::RedisCommandStatsSharedPtr redis_command_stats_;
   std::string auth_password_;
 };
 

--- a/test/extensions/filters/network/common/redis/client_impl_test.cc
+++ b/test/extensions/filters/network/common/redis/client_impl_test.cc
@@ -78,7 +78,7 @@ public:
     EXPECT_CALL(*upstream_connection_, connect());
     EXPECT_CALL(*upstream_connection_, noDelay(true));
 
-    const RedisCommandStats& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
+    const RedisCommandStatsSharedPtr& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
 
     client_ = ClientImpl::create(host_, dispatcher_, Common::Redis::EncoderPtr{encoder_}, *this,
                                  *config_, redis_command_stats, stats_);
@@ -432,6 +432,8 @@ TEST_F(RedisClientImplTest, CommandStatsEnabledTwoRequests) {
   Common::Redis::RespValue request1;
   initializeRedisSimpleCommand(&request1, get_command, "foo");
   MockClientCallbacks callbacks1;
+
+
   EXPECT_CALL(*encoder_, encode(Ref(request1), _));
   EXPECT_CALL(*flush_timer_, enabled()).WillOnce(Return(false));
   PoolRequest* handle1 = client_->makeRequest(request1, callbacks1);
@@ -1185,7 +1187,7 @@ TEST(RedisClientFactoryImplTest, Basic) {
   NiceMock<Event::MockDispatcher> dispatcher;
   ConfigImpl config(createConnPoolSettings());
   Stats::IsolatedStoreImpl stats_;
-  const RedisCommandStats& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
+  const RedisCommandStatsSharedPtr& redis_command_stats = Common::Redis::Client::ClientFactoryImpl::instance_.getOrCreateRedisCommandStats(stats_.symbolTable());
   const std::string auth_password;
   ClientPtr client =
       factory.create(host, dispatcher, config, redis_command_stats, stats_, auth_password);


### PR DESCRIPTION
This won't build completely; however it should build for the Redis client implementation test:

```
bazel test //test/extensions/filters/network/common/redis:client_impl_test --test_filter=RedisClientImplTest.CommandStatsEnabledTwoRequests --test_output=all --test_summary=detailed --cache_test_results=no --spawn_strategy=standalone --verbose_failures
```

It will then segfault with 

```
    Envoy::Stats::StatNameSet::~StatNameSet() symbol_table_impl.cc:550
    Envoy::Stats::StatNameSet::~StatNameSet() symbol_table_impl.cc:550
    std::__1::default_delete<Envoy::Stats::StatNameSet>::operator()(Envoy::Stats::StatNameSet*) const memory:2339
    std::__1::unique_ptr<Envoy::Stats::StatNameSet, std::__1::default_delete<Envoy::Stats::StatNameSet> >::reset(Envoy::Stats::StatNameSet*) memory:2652
    std::__1::unique_ptr<Envoy::Stats::StatNameSet, std::__1::default_delete<Envoy::Stats::StatNameSet> >::~unique_ptr() memory:2606
    std::__1::unique_ptr<Envoy::Stats::StatNameSet, std::__1::default_delete<Envoy::Stats::StatNameSet> >::~unique_ptr() memory:2606
    Envoy::Extensions::NetworkFilters::Common::Redis::RedisCommandStats::~RedisCommandStats() redis_command_stats.h:20
    Envoy::Extensions::NetworkFilters::Common::Redis::RedisCommandStats::~RedisCommandStats() redis_command_stats.h:20
    std::__1::__shared_ptr_emplace<Envoy::Extensions::NetworkFilters::Common::Redis::RedisCommandStats, std::__1::allocator<Envoy::Extensions::NetworkFilters::Common::Redis::RedisCommandStats> >::__on_zero_shared() memory:3710
    std::__1::__shared_count::__release_shared() memory:3544
    std::__1::__shared_weak_count::__release_shared() memory:3586
    std::__1::shared_ptr<Envoy::Test::Globals::TypedSingleton<Envoy::Event::SingletonTimeSystemHelper> >::~shared_ptr() memory:4522
    std::__1::shared_ptr<Envoy::Extensions::NetworkFilters::Common::Redis::RedisCommandStats>::~shared_ptr() memory:4520
    Envoy::Extensions::NetworkFilters::Common::Redis::Client::ClientFactoryImpl::~ClientFactoryImpl() client_impl.h:149
    Envoy::Extensions::NetworkFilters::Common::Redis::Client::ClientFactoryImpl::~ClientFactoryImpl() client_impl.h:149
    __cxa_finalize_ranges 0x00007fff78c463cf
    exit 0x00007fff78c466b3
    start 0x00007fff78ba03dc
```