### PR TITLE
draft fault injection supporting error fault only

### DIFF
--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -191,7 +191,7 @@ message RedisProxy {
 
     // Percentage of requests fault applies to.
     // TODO: How do we make this a required field
-    api.v2.core.RuntimeFractionalPercent runtime_fraction = 2;
+    api.v2.core.RuntimeFractionalPercent fault_enabled = 2;
 
     // Configureable delay for all faults. If not set, defaults to zero
     google.protobuf.Duration delay = 3;

--- a/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/api/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -24,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RedisProxy {
   // Redis connection pool settings.
   // [#next-free-field: 9]
@@ -174,6 +174,34 @@ message RedisProxy {
     Route catch_all_route = 4;
   }
 
+  // RedisFault defines faults used for fault injection.
+  // TODO: More explanation
+  message RedisFault {
+    enum RedisFaultType {
+      // Delays requests. This is the base fault; other faults can have delays added.
+      DELAY = 0;
+
+      // Returns errors on requests.
+      ERROR = 1;
+    }
+
+    // Fault type.
+    // TODO: How do we make this a required field
+    RedisFaultType fault_type = 1 [(validate.rules).enum = {defined_only: true}];
+
+    // Percentage of requests fault applies to.
+    // TODO: How do we make this a required field
+    api.v2.core.RuntimeFractionalPercent runtime_fraction = 2;
+
+    // Configureable delay for all faults. If not set, defaults to zero
+    google.protobuf.Duration delay = 3;
+    // TODO: Make this runtime-tuneable? Do we care- most delays aren't tuneable.
+
+    // Commands fault is restricted to, if any.
+    // TODO: Make this optional
+    repeated string commands = 4;
+  }
+
   // The prefix to use when emitting :ref:`statistics <config_network_filters_redis_proxy_stats>`.
   string stat_prefix = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -233,6 +261,10 @@ message RedisProxy {
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
   api.v2.core.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
+
+  // List of faults.
+  // TODO: More description, example config
+  repeated RedisFault faults = 7;
 }
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RedisProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
@@ -182,6 +182,36 @@ message RedisProxy {
     Route catch_all_route = 4;
   }
 
+  // RedisFault defines faults used for fault injection.
+  // TODO: More explanation
+  message RedisFault {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.filter.network.redis_proxy.v2.RedisProxy.RedisFault";
+
+    enum RedisFaultType {
+      // Delays requests. This is the base fault; other faults can have delays added.
+      DELAY = 0;
+
+      // Returns errors on requests.
+      ERROR = 1;
+    }
+
+    // Fault type.
+    // TODO: How do we make this a required field
+    RedisFaultType fault_type = 1 [(validate.rules).enum = {defined_only: true}];
+
+    // Percentage of requests fault applies to.
+    // TODO: How do we make this a required field
+    config.core.v3.RuntimeFractionalPercent runtime_fraction = 2;
+
+    // Configureable delay for all faults. If not set, defaults to zero
+    google.protobuf.Duration delay = 3;
+
+    // Commands fault is restricted to, if any.
+    // TODO: Make this optional
+    repeated string commands = 4;
+  }
+
   reserved 2;
 
   reserved "cluster";
@@ -234,6 +264,10 @@ message RedisProxy {
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
   config.core.v3.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
+
+  // List of faults.
+  // TODO: More description, example config
+  repeated RedisFault faults = 7;
 }
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in

--- a/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/api/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -202,10 +202,11 @@ message RedisProxy {
 
     // Percentage of requests fault applies to.
     // TODO: How do we make this a required field
-    config.core.v3.RuntimeFractionalPercent runtime_fraction = 2;
+    config.core.v3.RuntimeFractionalPercent fault_enabled = 2;
 
     // Configureable delay for all faults. If not set, defaults to zero
     google.protobuf.Duration delay = 3;
+    // TODO: Make this runtime-tuneable? Do we care- most delays aren't tuneable.
 
     // Commands fault is restricted to, if any.
     // TODO: Make this optional

--- a/generated_api_shadow/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/generated_api_shadow/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -191,10 +191,11 @@ message RedisProxy {
 
     // Percentage of requests fault applies to.
     // TODO: How do we make this a required field
-    api.v2.core.RuntimeFractionalPercent runtime_fraction = 2;
+    api.v2.core.RuntimeFractionalPercent fault_enabled = 2;
 
     // Configureable delay for all faults. If not set, defaults to zero
     google.protobuf.Duration delay = 3;
+    // TODO: Make this runtime-tuneable? Do we care- most delays aren't tuneable.
 
     // Commands fault is restricted to, if any.
     // TODO: Make this optional

--- a/generated_api_shadow/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
+++ b/generated_api_shadow/envoy/config/filter/network/redis_proxy/v2/redis_proxy.proto
@@ -24,7 +24,7 @@ option (udpa.annotations.file_status).package_version_status = ACTIVE;
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RedisProxy {
   // Redis connection pool settings.
   // [#next-free-field: 9]
@@ -174,6 +174,33 @@ message RedisProxy {
     Route catch_all_route = 4;
   }
 
+  // RedisFault defines faults used for fault injection.
+  // TODO: More explanation
+  message RedisFault {
+    enum RedisFaultType {
+      // Delays requests. This is the base fault; other faults can have delays added.
+      DELAY = 0;
+
+      // Returns errors on requests.
+      ERROR = 1;
+    }
+
+    // Fault type.
+    // TODO: How do we make this a required field
+    RedisFaultType fault_type = 1 [(validate.rules).enum = {defined_only: true}];
+
+    // Percentage of requests fault applies to.
+    // TODO: How do we make this a required field
+    api.v2.core.RuntimeFractionalPercent runtime_fraction = 2;
+
+    // Configureable delay for all faults. If not set, defaults to zero
+    google.protobuf.Duration delay = 3;
+
+    // Commands fault is restricted to, if any.
+    // TODO: Make this optional
+    repeated string commands = 4;
+  }
+
   // The prefix to use when emitting :ref:`statistics <config_network_filters_redis_proxy_stats>`.
   string stat_prefix = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -233,6 +260,10 @@ message RedisProxy {
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
   api.v2.core.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
+
+  // List of faults.
+  // TODO: More description, example config
+  repeated RedisFault faults = 7;
 }
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -208,10 +208,11 @@ message RedisProxy {
 
     // Percentage of requests fault applies to.
     // TODO: How do we make this a required field
-    config.core.v3.RuntimeFractionalPercent runtime_fraction = 2;
+    config.core.v3.RuntimeFractionalPercent fault_enabled = 2;
 
     // Configureable delay for all faults. If not set, defaults to zero
     google.protobuf.Duration delay = 3;
+    // TODO: Make this runtime-tuneable? Do we care- most delays aren't tuneable.
 
     // Commands fault is restricted to, if any.
     // TODO: Make this optional

--- a/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
+++ b/generated_api_shadow/envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.proto
@@ -22,7 +22,7 @@ option (udpa.annotations.file_status).package_version_status = NEXT_MAJOR_VERSIO
 // Redis Proxy :ref:`configuration overview <config_network_filters_redis_proxy>`.
 // [#extension: envoy.filters.network.redis_proxy]
 
-// [#next-free-field: 7]
+// [#next-free-field: 8]
 message RedisProxy {
   option (udpa.annotations.versioning).previous_message_type =
       "envoy.config.filter.network.redis_proxy.v2.RedisProxy";
@@ -188,6 +188,36 @@ message RedisProxy {
     Route catch_all_route = 4;
   }
 
+  // RedisFault defines faults used for fault injection.
+  // TODO: More explanation
+  message RedisFault {
+    option (udpa.annotations.versioning).previous_message_type =
+        "envoy.config.filter.network.redis_proxy.v2.RedisProxy.RedisFault";
+
+    enum RedisFaultType {
+      // Delays requests. This is the base fault; other faults can have delays added.
+      DELAY = 0;
+
+      // Returns errors on requests.
+      ERROR = 1;
+    }
+
+    // Fault type.
+    // TODO: How do we make this a required field
+    RedisFaultType fault_type = 1 [(validate.rules).enum = {defined_only: true}];
+
+    // Percentage of requests fault applies to.
+    // TODO: How do we make this a required field
+    config.core.v3.RuntimeFractionalPercent runtime_fraction = 2;
+
+    // Configureable delay for all faults. If not set, defaults to zero
+    google.protobuf.Duration delay = 3;
+
+    // Commands fault is restricted to, if any.
+    // TODO: Make this optional
+    repeated string commands = 4;
+  }
+
   // The prefix to use when emitting :ref:`statistics <config_network_filters_redis_proxy_stats>`.
   string stat_prefix = 1 [(validate.rules).string = {min_bytes: 1}];
 
@@ -248,6 +278,10 @@ message RedisProxy {
   // client. If an AUTH command is received when the password is not set, then an "ERR Client sent
   // AUTH, but no password is set" error will be returned.
   config.core.v3.DataSource downstream_auth_password = 6 [(udpa.annotations.sensitive) = true];
+
+  // List of faults.
+  // TODO: More description, example config
+  repeated RedisFault faults = 7;
 }
 
 // RedisProtocolOptions specifies Redis upstream protocol options. This object is used in

--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -99,3 +99,16 @@ envoy_cc_library(
         "//source/common/stats:timespan_lib",
     ],
 )
+
+
+envoy_cc_library(
+    name = "fault_lib",
+    srcs = ["fault.cc"],
+    hdrs = ["fault.h"],
+    deps = [
+        ":codec_lib",
+        "//include/envoy/upstream:upstream_interface",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/filters/network/redis_proxy/v3:pkg_cc_proto",
+    ],
+)

--- a/source/extensions/filters/network/common/redis/fault.cc
+++ b/source/extensions/filters/network/common/redis/fault.cc
@@ -79,19 +79,19 @@ namespace Redis {
 
     // TODO: Check if this is ok
   uint64_t RedisFaultManager::calculate_fault_injection_percentage(envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault& fault) {
-      if (fault.has_runtime_fraction()) {
-        if (fault.runtime_fraction().has_default_value()) {
-          envoy::type::v3::FractionalPercent default_value = fault.runtime_fraction().default_value();
+      if (fault.has_fault_enabled()) {
+        if (fault.fault_enabled().has_default_value()) {
+          envoy::type::v3::FractionalPercent default_value = fault.fault_enabled().default_value();
           if (default_value.denominator() == envoy::type::v3::FractionalPercent::HUNDRED) {
-            return runtime_.snapshot().getInteger(fault.runtime_fraction().runtime_key(), default_value.numerator());
+            return runtime_.snapshot().getInteger(fault.fault_enabled().runtime_key(), default_value.numerator());
           } else {
             int denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(default_value.denominator());
             int adjusted_numerator = (default_value.numerator() * 100) / denominator;
-            return runtime_.snapshot().getInteger(fault.runtime_fraction().runtime_key(), adjusted_numerator);
+            return runtime_.snapshot().getInteger(fault.fault_enabled().runtime_key(), adjusted_numerator);
           }
         } else {
           // Default value is zero if not set
-          return runtime_.snapshot().getInteger(fault.runtime_fraction().runtime_key(), 0);
+          return runtime_.snapshot().getInteger(fault.fault_enabled().runtime_key(), 0);
         }
       } else {
         // Default action- no fault injection

--- a/source/extensions/filters/network/common/redis/fault.cc
+++ b/source/extensions/filters/network/common/redis/fault.cc
@@ -1,0 +1,122 @@
+#include "extensions/filters/network/common/redis/fault.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+
+  RedisFaultManager::RedisFaultManager(Runtime::RandomGenerator& random, Runtime::Loader& runtime, const ::google::protobuf::RepeatedPtrField< ::envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault> faults) : random_(random), runtime_(runtime) {
+    // Group faults by command
+    for (auto fault : faults) {
+      if (fault.commands_size() > 0) {
+        for (auto& command: fault.commands()) {
+          std::cout << "Inserting fault for command: " << absl::AsciiStrToLower(command) << " with type: " << fault.GetTypeName() << std::endl;
+          fault_map_.insert(FaultMapType::value_type(absl::AsciiStrToLower(command), fault));
+        }
+      } else {
+        // Generic "ALL" entry in map
+        std::cout << "Inserting fault for all: " << ALL_KEY << std::endl;
+        fault_map_.insert(FaultMapType::value_type(ALL_KEY, fault));
+      }
+    }
+  }
+
+  absl::optional<std::pair<FaultType, std::chrono::milliseconds>> RedisFaultManager::get_fault_for_command(std::string command) {
+    // Fault checking algorithm:
+    //
+    // For example, if we have an ERROR fault at 5% for all commands, and a DELAY fault at 10% for GET, if
+    // we receive a GET, we want 5% of GETs to get DELAY, and 5% to get ERROR. Thus, we need to amortize the
+    // percentages.
+    //
+    // 1. Set amortized_fault to 0
+    // 2. Look for command specific faults
+    // 3. For each command specific fault
+    //  a. check if it applies, using 100 - amortized_fault as modulo for random
+    //  b. if (a), return a pair of fault type and delay, if any
+    //  c. if (!a), add fault percentage to amortized_fault
+    // 4. For each general fault, repeat the process in (3)
+    // 5. If we did not hit any faults, return null;
+
+    if (!fault_map_.empty()) {
+      int amortized_fault = 0;
+
+      // TODO: Make sure this math is right!!!
+      // TODO: Do we need to create a temporary map? Think about perf.
+
+      // Look for command specific faults first
+      for (auto it = fault_map_.find(command); it != fault_map_.end(); it++) {
+        std::cout << "\t" << "found command-specific fault for command '" << command << "'" << std::endl;
+        envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault fault = it->second;
+        const uint64_t fault_injection_percentage = calculate_fault_injection_percentage(fault);
+        std::cout << "\t\t" << "fault_injection_percentage = " << fault_injection_percentage << ", amortized_fault = " << amortized_fault << std::endl;
+        if (random_.random() % (100 - amortized_fault) < fault_injection_percentage) {
+          std::cout << "\t\t" << "injecting command specific fault" << std::endl;
+          return std::make_pair(get_fault_type(fault), get_fault_delay_ms(fault));
+        } else {
+          amortized_fault += fault_injection_percentage;
+        }
+      }
+
+      // If that fails, look at faults that apply to all commands
+      for (auto it = fault_map_.find(ALL_KEY); it != fault_map_.end(); it++) {
+        std::cout << "\t" << "found general fault" << std::endl;
+        envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault fault = it->second;
+        const uint64_t fault_injection_percentage = calculate_fault_injection_percentage(fault);
+        std::cout << "\t\t" << "fault_injection_percentage = " << fault_injection_percentage << ", amortized_fault = " << amortized_fault << std::endl;
+        if (random_.random() % (100 - amortized_fault) < fault_injection_percentage) {
+          std::cout << "\t\t" << "injecting general fault" << std::endl;
+          return std::make_pair(get_fault_type(fault), get_fault_delay_ms(fault));
+        } else {
+          amortized_fault += fault_injection_percentage;
+        }
+      }
+    }
+
+    // No faults injected!
+    return absl::nullopt;
+  }
+
+    // TODO: Check if this is ok
+  uint64_t RedisFaultManager::calculate_fault_injection_percentage(envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault& fault) {
+      if (fault.has_runtime_fraction()) {
+        if (fault.runtime_fraction().has_default_value()) {
+          envoy::type::v3::FractionalPercent default_value = fault.runtime_fraction().default_value();
+          if (default_value.denominator() == envoy::type::v3::FractionalPercent::HUNDRED) {
+            return runtime_.snapshot().getInteger(fault.runtime_fraction().runtime_key(), default_value.numerator());
+          } else {
+            int denominator = ProtobufPercentHelper::fractionalPercentDenominatorToInt(default_value.denominator());
+            int adjusted_numerator = (default_value.numerator() * 100) / denominator;
+            return runtime_.snapshot().getInteger(fault.runtime_fraction().runtime_key(), adjusted_numerator);
+          }
+        } else {
+          // Default value is zero if not set
+          return runtime_.snapshot().getInteger(fault.runtime_fraction().runtime_key(), 0);
+        }
+      } else {
+        // Default action- no fault injection
+        return 0;
+      }
+  }
+
+  std::chrono::milliseconds RedisFaultManager::get_fault_delay_ms(envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault& fault) {
+    return std::chrono::milliseconds(PROTOBUF_GET_MS_OR_DEFAULT(fault, delay, 0));
+  }
+
+  FaultType RedisFaultManager::get_fault_type(envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault& fault) {
+    switch (fault.fault_type()) {
+    case envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::RedisFault::DELAY:
+      return FaultType::Delay;
+    case envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::RedisFault::ERROR:
+      return FaultType::Error;
+    default:
+      NOT_REACHED_GCOVR_EXCL_LINE;
+      break;
+    }
+  }
+
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/common/redis/fault.h
+++ b/source/extensions/filters/network/common/redis/fault.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <list>
+
+#include "envoy/api/api.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.h"
+#include "envoy/extensions/filters/network/redis_proxy/v3/redis_proxy.pb.validate.h"
+#include "envoy/upstream/upstream.h"
+
+// #include "common/common/empty_string.h"
+// #include "common/config/datasource.h"
+
+// #include "extensions/filters/network/common/factory_base.h"
+// #include "extensions/filters/network/well_known_names.h"
+
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace Common {
+namespace Redis {
+
+// Fault Injection TODO Priority
+// 1. Figure out how to get values off the runtime fraction.
+
+
+// TODO: Move fault classes
+// TODO: Check if there is a runtime hook that updates fault_values. If not, we probably only want to get the config percentages
+// every X requests (ie 1000 or more)?
+
+/**
+ * Read policy to use for Redis cluster.
+ */
+enum class FaultType { Delay, Error };
+
+class RedisFaultManager {
+  typedef std::multimap<std::string, envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault> FaultMapType;
+
+  public:
+  RedisFaultManager(Runtime::RandomGenerator& random, Runtime::Loader& runtime, const ::google::protobuf::RepeatedPtrField< ::envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault> faults);
+
+  absl::optional<std::pair<FaultType, std::chrono::milliseconds>> get_fault_for_command(std::string command);
+  
+  private:
+  uint64_t calculate_fault_injection_percentage(envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault& fault);
+  std::chrono::milliseconds get_fault_delay_ms(envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault& fault);
+  FaultType get_fault_type(envoy::extensions::filters::network::redis_proxy::v3::RedisProxy_RedisFault& fault);
+
+  const std::string ALL_KEY = "ALL_KEYS";
+  FaultMapType fault_map_;
+  Runtime::RandomGenerator& random_;
+  Runtime::Loader& runtime_;
+};
+
+} // namespace Redis
+} // namespace Common
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -110,6 +110,7 @@ envoy_cc_library(
         "//source/common/config:datasource_lib",
         "//source/common/config:utility_lib",
         "//source/extensions/filters/network/common/redis:codec_interface",
+                "//source/extensions/filters/network/common/redis:fault_lib",
         "@envoy_api//envoy/extensions/filters/network/redis_proxy/v3:pkg_cc_proto",
     ],
 )

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -41,7 +41,7 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
           context.timeSource());
 
   ProxyFilterConfigSharedPtr filter_config(std::make_shared<ProxyFilterConfig>(
-      proto_config, context.scope(), context.drainDecision(), context.runtime(), context.api()));
+      proto_config, context.scope(), context.drainDecision(), context.runtime(), context.api(), context.random()));
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::PrefixRoutes prefix_routes(
       proto_config.prefix_routes());
@@ -95,6 +95,7 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
     filter_manager.addReadFilter(std::make_shared<ProxyFilter>(
         factory, Common::Redis::EncoderPtr{new Common::Redis::EncoderImpl()}, *splitter,
         filter_config));
+        // TODO: Add dispatcher to proxy filter proper, allowing us to perform delays there
   };
 }
 

--- a/source/extensions/filters/network/redis_proxy/config.cc
+++ b/source/extensions/filters/network/redis_proxy/config.cc
@@ -41,7 +41,7 @@ Network::FilterFactoryCb RedisProxyFilterConfigFactory::createFilterFactoryFromP
           context.timeSource());
 
   ProxyFilterConfigSharedPtr filter_config(std::make_shared<ProxyFilterConfig>(
-      proto_config, context.scope(), context.drainDecision(), context.runtime(), context.api(), context.random()));
+      proto_config, context.scope(), context.drainDecision(), context.runtime(), context.api(), context.random(), context.dispatcher()));
 
   envoy::extensions::filters::network::redis_proxy::v3::RedisProxy::PrefixRoutes prefix_routes(
       proto_config.prefix_routes());

--- a/source/extensions/filters/network/redis_proxy/config.h
+++ b/source/extensions/filters/network/redis_proxy/config.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <map>
+#include <list>
 
 #include "envoy/api/api.h"
 #include "envoy/config/core/v3/base.pb.h"


### PR DESCRIPTION
Important points:

- Redis fault manager class to manage storing map of commands to whatever faults apply, as well as telling envoy what faults should be used at request time
- Fault manager is called by `void ProxyFilter::onRespValue(Common::Redis::RespValuePtr&& value)`, where we perform the desired action- ie send an error response. I've hardcoded the command right now- I'll add a util function to parse the command (move it out of redis command stats to the other Redis protocol classes).
- Storing fault objects in multimap on fault manager; should I store pointers or do this some other way? Thread saftey issues?
- We discussed storing the table of command -> fault probabilities and recalculating them; I am not doing that in this draft; is that still necessary if we don't walk through all faults and just check the runtime each request as we do for other things?
- There may be a few little things I need to clean up from moving things around a bit (ie fault manager's construction in proxy filter config, rather than config.cc).
- No tests yet!

Reference `envoy.yaml` that I've been using to validate this, along with `redis-cli`:

```
admin:
  access_log_path: "/dev/null"
  address:
    socket_address:
      protocol: TCP
      address: 0.0.0.0
      port_value: 8001
static_resources:
  listeners:
  - name: redis_listener
    address:
      socket_address:
        address: 0.0.0.0
        port_value: 22120 
    filter_chains:
    - filters:
      - name: envoy.filters.network.redis_proxy
        typed_config:
          "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
          stat_prefix: egress_redis
          settings:
            op_timeout: 5s
          prefix_routes:
            catch_all_route:
              cluster: redis_cluster
          faults:
          - fault_type: ERROR
            runtime_fraction:
              default_value:
                numerator: 50
                denominator: HUNDRED
              runtime_key: "bogus_key"
            delay: 0s
            commands:
            - GET
  clusters:
  - name: redis_cluster
    connect_timeout: 1s
    type: strict_dns # static
    lb_policy: MAGLEV
    load_assignment:
      cluster_name: redis_cluster
      endpoints:
      - lb_endpoints:
        - endpoint:
            address:
              socket_address:
                address: 127.0.0.1 
                port_value: 6379
```